### PR TITLE
performance project was renamed to pyperformance

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,7 +50,7 @@ Quick Links:
 
 Other Python benchmark projects:
 
-* `performance <https://pypi.python.org/pypi/performance>`_: the Python
+* `pyperformance <https://pypi.python.org/pypi/pyperformance>`_: the Python
   benchmark suite which uses ``pyperf``
 * `Python speed mailing list
   <https://mail.python.org/mailman/listinfo/speed>`_


### PR DESCRIPTION
I had never heard of the `performance` project so I clicked the link out of curiosity. After seeing the 404 it dawned on me that `performance` was probably the former name of `pyperformance`, a project I had seen before. A quick check of the change log confirmed my suspicion :-)