### PR TITLE
Support of Python 3.9 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ jobs:
       env: TOX_ENV=doc
     - python: '3.8'
       env: TOX_ENV=pep8
-    # FIXME: At 2020-10-26, '3.9' is not accepted by Travis CI yet.
-    # Python 3.9.0 was released at 2020-10-05.
-    - python: '3.9-dev'
+    - python: '3.9'
       env: TOX_ENV=py3
 
 install:


### PR DESCRIPTION
First of all sorry for the confusion on my previous PR, this time all should go well. Travis-CI started giving support for Python 3.9 [https://travis-ci.community/t/python-3-9-0-build/10091/17](https://travis-ci.community/t/python-3-9-0-build/10091/17).