### PR TITLE
CI: Enable macOS CI and update test_timeit.py to pass 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,30 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
         python: [3.6, 3.7, 3.8, 3.9]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py
+
+  build_macos:
+    name: 'macOS'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,11 @@ jobs:
   build:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest]
+        python: [3.9]
+        include:
+          - python: [3.6, 3.7, 3.8]
+            os: ubuntu-latest
 
     runs-on: ubuntu-latest
     steps:
@@ -19,21 +23,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Tox and any other packages
-        run: pip install tox
-      - name: Run Tox
-        # Run tox using the version of Python in `PATH`
-        run: tox -e py
-
-  build_macos:
-    name: 'macOS'
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python: [3.9]
         include:
-          - python: [3.6, 3.7, 3.8]
-            os: ubuntu-latest
+          - os: ubuntu-latest
+            python: 3.6
+          - os: ubuntu-latest
+            python: 3.7
+          - os: ubuntu-latest
+            python: 3.8
 
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/pyperf/tests/test_timeit.py
+++ b/pyperf/tests/test_timeit.py
@@ -7,6 +7,8 @@ import tempfile
 import textwrap
 import unittest
 
+from pathlib import Path
+
 import pyperf
 from pyperf import tests
 from pyperf._timeit import Timer
@@ -242,6 +244,7 @@ class TestTimeit(unittest.TestCase):
                 if exc.errno != errno.ENOENT:
                     raise
 
+        tmp_exe = Path(tmp_exe).resolve()
         self.assertEqual(cmd.returncode, 0, repr(cmd.stdout + cmd.stderr))
         self.assertIn("python_executable: %s" % tmp_exe, cmd.stdout)
 


### PR DESCRIPTION
The test was failed due to different symbolic link handling for tmp_exe

```
Traceback (most recent call last):
  File "/Users/user/oss/pyperf/pyperf/tests/test_timeit.py", line 246, in test_python_option
    self.assertIn("python_executable: %s" % tmp_exe, cmd.stdout)
AssertionError: 'python_executable: /var/folders/mc/1ytklbws2m5gc32q6ttsqnsh0000gn/T/tmphtu26goe' not found in ".\nMetadata:\n- boot_time: 2021-03-13 01:32:00\n- cpu_count: 12\n- date: 2021-03-13 01:38:04.830475\n- duration: 20.4 ms\n- hostname: AL01727201.local\n- load_avg_1min: 1.61\n- loops: 1\n- mem_max_rss: 12252.0 MB\n- name: timeit\n- perf_version: 2.1.1\n- platform: macOS-10.16-x86_64-i386-64bit\n- python_cflags: -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g\n- python_compiler: Clang 6.0 (clang-600.0.57)\n- python_executable: /private/var/folders/mc/1ytklbws2m5gc32q6ttsqnsh0000gn/T/tmphtu26goe\n- python_implementation: cpython\n- python_version: 3.9.1 (64-bit) revision 1e5d33e9b9\n- timeit_setup: 'import time'\n- timeit_stmt: 'time.sleep(1e-6)'\n- timer: mach_absolute_time(), resolution: 1.00 ns\n- unit: second\n- uptime: 6 min 4.8 sec\n\nWARNING: the benchmark result may be unstable\n* the shortest raw value is only 16.0 us\n\nTry to rerun the benchmark with more runs, values and/or loops.\nRun 'python -m pyperf system tune' command to reduce the system jitter.\nUse pyperf stats, pyperf dump and pyperf hist to analyze results.\nUse --quiet option to hide these warnings.\n\n16.0 us\n"
``` 