### PR TITLE
Fix memory unit for macOS when calculating ru_maxrss

### DIFF
--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -28,6 +28,8 @@ except ImportError:
 def get_max_rss():
     if resource is not None:
         usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        if sys.platform == 'darwin':
+            return usage.ru_maxrss
         return usage.ru_maxrss * 1024
     else:
         return 0


### PR DESCRIPTION
## AS-IS
```
(.tmp) ➜  pyperf git:(main) ✗ python -m pyperf command --track-memory python -c pass
.....................
command: Mean +- std dev: 5288.8 MB +- 60.9 MB
```
## TO-BE
```
(.tmp) ➜  pyperf git:(main) ✗ python -m pyperf command --track-memory python -c pass
.....................
command: Mean +- std dev: 5315.4 kB +- 75.8 kB
```