### PR TITLE
Implement 'faster on x% of runs'

### DIFF
--- a/pyperf/__main__.py
+++ b/pyperf/__main__.py
@@ -108,6 +108,8 @@ def create_parser():
                      help='Absolute minimum of speed in percent to '
                           'consider that a benchmark is significant '
                           '(default: 0%%)')
+    cmd.add_argument('--win_percentage', action="store_true",
+                     help="Show how often a benchmark is faster.")
     cmd.add_argument('--table', action="store_true",
                      help='Render a table')
     cmd.add_argument("--table-format", type=str, default="rest",

--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -403,3 +403,29 @@ def geometric_mean(data):
     if not data:
         raise ValueError("empty data")
     return _geometric_mean(data)
+
+
+def _count_pairs_less_than(list1, list2):
+    # counts sum(x < y for x in list1 for y in list2)
+    # list1 and list2 should be sorted
+    i = 0
+    count = 0
+    for x in list2:
+        while i < len(list1) and list1[i] < x:
+            i += 1
+        # x is bigger than all of list1[:i]
+        count += i
+    return count
+
+
+def percentage_less_than(list1, list2):
+    # measures mean(x < y for x in list1 for y in list2)
+    list1 = sorted(list1)
+    list2 = sorted(list2)
+    list1_less = _count_pairs_less_than(list1, list2)
+    list2_less = _count_pairs_less_than(list2, list1)
+    product = len(list1) * len(list2)
+    if product == 0:
+        raise ValueError("Can't compute percentages of empty samples")
+    ties = product - list1_less - list2_less
+    return (list1_less + ties / 2) / product


### PR DESCRIPTION
Based on https://github.com/psf/pyperf/issues/22:

Example:


```
py -m pyperf compare_to ..\cpython\floatbench.json ..\multiply\floatbench.json --table --win_percentage
+----------------+----------------------------+-----------------------------------------------+
| Benchmark      | ..\cpython\floatbench.json | ..\multiply\floatbench.json                   |
+================+============================+===============================================+
| int: x*x       | 28.5 ns                    | 27.7 ns: 1.03x faster (faster on 88% of runs) |
+----------------+----------------------------+-----------------------------------------------+
| float: x*x     | 28.4 ns                    | 27.9 ns: 1.02x faster (faster on 80% of runs) |
+----------------+----------------------------+-----------------------------------------------+
| int: x*...*x   | 262 ms                     | 220 ms: 1.19x faster (faster on 100% of runs) |
+----------------+----------------------------+-----------------------------------------------+
| float: x*...*x | 260 ms                     | 253 ms: 1.03x faster (faster on 90% of runs)  |
+----------------+----------------------------+-----------------------------------------------+
| Geometric mean | (ref)                      | 1.06x faster                                  |
+----------------+----------------------------+-----------------------------------------------+
```

I've not worked with this code before, so let me know what needs fixing.