### PR TITLE
Support reporting geometric mean by benchmark tags

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -676,6 +676,7 @@ Benchmark:
 * ``inner_loops`` (``int >= 1``): number of inner-loops of the benchmark (``int``)
 * ``timer``: Implementation of ``time.perf_counter()``, and also resolution if
   available
+* ``tags``: (list of str, optional): A list of tags associated with the benchmark. If provided, the results output will be aggreggated by each tag.
 
 Python metadata:
 
@@ -831,6 +832,7 @@ Example of JSON, ``...`` is used in the example for readability::
             "loops": 8,
             "name": "telco",
             "perf_version": "0.8.2",
+            "tags": ["numeric"],
             ...
         },
         "version": "1.0"

--- a/pyperf/_metadata.py
+++ b/pyperf/_metadata.py
@@ -42,6 +42,12 @@ def is_positive(value):
     return (value >= 0)
 
 
+def is_tags(value):
+    if not isinstance(value, list):
+        return False
+    return all(isinstance(x, str) and x not in ('all', '') for x in value)
+
+
 def parse_load_avg(value):
     if isinstance(value, NUMBER_TYPES):
         return value
@@ -62,6 +68,7 @@ DATETIME = _MetadataInfo(format_noop, (str,), None, None)
 LOOPS = _MetadataInfo(format_number, (int,), is_strictly_positive, 'integer')
 WARMUPS = _MetadataInfo(format_number, (int,), is_positive, 'integer')
 SECONDS = _MetadataInfo(format_seconds, NUMBER_TYPES, is_positive, 'second')
+TAGS = _MetadataInfo(format_generic, (list,), is_tags, 'tag')
 
 # Registry of metadata keys
 METADATA = {
@@ -84,6 +91,7 @@ METADATA = {
     'recalibrate_loops': LOOPS,
     'calibrate_warmups': WARMUPS,
     'recalibrate_warmups': WARMUPS,
+    'tags': TAGS,
 }
 
 DEFAULT_METADATA_INFO = _MetadataInfo(format_generic, METADATA_VALUE_TYPES, None, None)

--- a/pyperf/tests/mult_list_py36_tags.json
+++ b/pyperf/tests/mult_list_py36_tags.json
@@ -1,0 +1,1575 @@
+{
+    "version": "1.0",
+    "metadata": {
+        "unit": "second",
+        "timer": "clock_gettime(CLOCK_MONOTONIC), resolution: 1.00 ns",
+        "timeit_teardown": "'pass'",
+        "timeit_setup": "'pass'",
+        "timeit_duplicate": 1024,
+        "python_version": "3.6.12 (64-bit)",
+        "python_implementation": "cpython",
+        "python_executable": "/usr/bin/python3.6",
+        "python_compiler": "GCC 10.2.1 20200723 (Red Hat 10.2.1-1)",
+        "python_cflags": "-Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv",
+        "platform": "Linux-5.8.12-200.fc32.x86_64-x86_64-with-fedora-32-Thirty_Two",
+        "perf_version": "2.0.1",
+        "inner_loops": 1024,
+        "hostname": "apu",
+        "cpu_model_name": "Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz",
+        "cpu_count": 8,
+        "cpu_config": "0-7=driver:intel_pstate, intel_pstate:turbo, governor:powersave; idle:intel_idle",
+        "boot_time": "2020-10-05 19:26:58",
+        "aslr": "Full randomization"
+    },
+    "benchmarks": [
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            2.136275384145847e-06
+                        ],
+                        [
+                            2,
+                            2.271278319199155e-06
+                        ],
+                        [
+                            4,
+                            2.0336750523597402e-06
+                        ],
+                        [
+                            8,
+                            2.119816773671346e-06
+                        ],
+                        [
+                            16,
+                            2.1169965211953468e-06
+                        ],
+                        [
+                            32,
+                            2.1113157657737247e-06
+                        ],
+                        [
+                            64,
+                            2.0968463290138573e-06
+                        ],
+                        [
+                            64,
+                            2.0622498015931967e-06
+                        ],
+                        [
+                            64,
+                            2.1096560058886382e-06
+                        ],
+                        [
+                            64,
+                            2.068039291369672e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 657922.4809143543,
+                        "mem_max_rss": 14929920,
+                        "load_avg_1min": 0.45,
+                        "duration": 0.7466293959878385,
+                        "date": "2020-10-13 10:12:20.476957",
+                        "cpu_temp": "coretemp:Package id 0=44 C, coretemp:Core 0=39 C, coretemp:Core 1=44 C, coretemp:Core 2=39 C, coretemp:Core 3=40 C",
+                        "cpu_freq": "0=3258 MHz; 1=3275 MHz; 2=3211 MHz; 3=3226 MHz; 4=3333 MHz; 5=3439 MHz; 6=3223 MHz; 7=3302 MHz",
+                        "calibrate_loops": 64
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0730591279161104e-06
+                        ]
+                    ],
+                    "values": [
+                        2.087224121094522e-06,
+                        2.1127525786646117e-06,
+                        2.1118663786623415e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657923.1394765377,
+                        "mem_max_rss": 14811136,
+                        "load_avg_1min": 0.45,
+                        "duration": 0.5809460970049258,
+                        "date": "2020-10-13 10:12:21.135682",
+                        "cpu_temp": "coretemp:Package id 0=44 C, coretemp:Core 0=39 C, coretemp:Core 1=44 C, coretemp:Core 2=39 C, coretemp:Core 3=40 C",
+                        "cpu_freq": "0=3475 MHz; 1=3246 MHz; 2=3310 MHz; 3=3319 MHz; 4=3274 MHz; 5=3370 MHz; 6=3321 MHz; 7=3297 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1152118225842287e-06
+                        ]
+                    ],
+                    "values": [
+                        2.129757262991916e-06,
+                        2.1172428130711296e-06,
+                        2.0969857481567544e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657923.7879779339,
+                        "mem_max_rss": 14839808,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.5861376130196732,
+                        "date": "2020-10-13 10:12:21.784371",
+                        "cpu_temp": "coretemp:Package id 0=53 C, coretemp:Core 0=54 C, coretemp:Core 1=39 C, coretemp:Core 2=42 C, coretemp:Core 3=41 C",
+                        "cpu_freq": "0=3483 MHz; 1=3373 MHz; 2=3382 MHz; 3=3350 MHz; 4=3435 MHz; 5=3365 MHz; 6=3323 MHz; 7=3356 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0912013551921405e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1451388851900788e-06,
+                        2.2766982574751182e-06,
+                        2.278493438812035e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657924.4595022202,
+                        "mem_max_rss": 14905344,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.609129529009806,
+                        "date": "2020-10-13 10:12:22.455739",
+                        "cpu_temp": "coretemp:Package id 0=53 C, coretemp:Core 0=54 C, coretemp:Core 1=39 C, coretemp:Core 2=42 C, coretemp:Core 3=41 C",
+                        "cpu_freq": "0=3462 MHz; 1=3247 MHz; 2=3198 MHz; 3=3120 MHz; 4=3250 MHz; 5=3210 MHz; 6=3203 MHz; 7=3263 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1736344604228464e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1558759155659857e-06,
+                        2.1976692350378357e-06,
+                        2.3945132596736585e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657925.1488056183,
+                        "mem_max_rss": 14893056,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.6231269449926913,
+                        "date": "2020-10-13 10:12:23.144983",
+                        "cpu_temp": "coretemp:Package id 0=53 C, coretemp:Core 0=44 C, coretemp:Core 1=41 C, coretemp:Core 2=44 C, coretemp:Core 3=54 C",
+                        "cpu_freq": "0=3349 MHz; 1=3190 MHz; 2=3173 MHz; 3=3212 MHz; 4=3202 MHz; 5=3199 MHz; 6=3155 MHz; 7=3285 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.17900166310514e-06
+                        ]
+                    ],
+                    "values": [
+                        2.172610015893639e-06,
+                        2.17672776781086e-06,
+                        2.084439818972328e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657925.8179106712,
+                        "mem_max_rss": 14860288,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.596170329983579,
+                        "date": "2020-10-13 10:12:23.814290",
+                        "cpu_temp": "coretemp:Package id 0=53 C, coretemp:Core 0=44 C, coretemp:Core 1=41 C, coretemp:Core 2=44 C, coretemp:Core 3=54 C",
+                        "cpu_freq": "0=3400 MHz; 1=3249 MHz; 2=3229 MHz; 3=3028 MHz; 4=3482 MHz; 5=3230 MHz; 6=3242 MHz; 7=3084 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1346655731946385e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1586860503575167e-06,
+                        2.356745849585451e-06,
+                        2.1411605684029666e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657926.48812747,
+                        "mem_max_rss": 14942208,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.6098337970033754,
+                        "date": "2020-10-13 10:12:24.484412",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=42 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3397 MHz; 1=3080 MHz; 2=2951 MHz; 3=3173 MHz; 4=3432 MHz; 5=3223 MHz; 6=3233 MHz; 7=3150 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.143077804550586e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1632330624576923e-06,
+                        2.14184605384915e-06,
+                        2.1472478182182897e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657927.1456749439,
+                        "mem_max_rss": 14827520,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.5949904689914547,
+                        "date": "2020-10-13 10:12:25.141880",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=42 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3353 MHz; 1=3326 MHz; 2=3333 MHz; 3=3320 MHz; 4=3471 MHz; 5=3365 MHz; 6=3327 MHz; 7=3290 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0903774107239315e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1642797243259793e-06,
+                        2.113652572521829e-06,
+                        2.0886137388487214e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657927.7919530869,
+                        "mem_max_rss": 14729216,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.5857995249971282,
+                        "date": "2020-10-13 10:12:25.788193",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=40 C, coretemp:Core 2=43 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3433 MHz; 1=3377 MHz; 2=3361 MHz; 3=3354 MHz; 4=3483 MHz; 5=3380 MHz; 6=3369 MHz; 7=3375 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.091413391358543e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1048243405985545e-06,
+                        2.0983354493964157e-06,
+                        2.089667938243167e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657928.4352829456,
+                        "mem_max_rss": 14753792,
+                        "load_avg_1min": 0.49,
+                        "duration": 0.5815879180154298,
+                        "date": "2020-10-13 10:12:26.431665",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=40 C, coretemp:Core 2=43 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3450 MHz; 1=3400 MHz; 2,6=3366 MHz; 3=3367 MHz; 4=3488 MHz; 5=3369 MHz; 7=3385 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1103491363305693e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0843625336830485e-06,
+                        2.0716541899723495e-06,
+                        2.0928385620067047e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657929.0760879517,
+                        "mem_max_rss": 14790656,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5793534959957469,
+                        "date": "2020-10-13 10:12:27.072277",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=55 C, coretemp:Core 1=41 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3424 MHz; 1=3373 MHz; 2=3371 MHz; 3=3367 MHz; 4=3485 MHz; 5=3384 MHz; 6=3368 MHz; 7=3369 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1217134702489204e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0607452242416002e-06,
+                        2.1271756134311204e-06,
+                        2.0769277040422196e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657929.7199544907,
+                        "mem_max_rss": 14835712,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5819127279974055,
+                        "date": "2020-10-13 10:12:27.716142",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=55 C, coretemp:Core 1=41 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3386 MHz; 1=3329 MHz; 2=3300 MHz; 3=3353 MHz; 4=3474 MHz; 5=3385 MHz; 6=3345 MHz; 7=3374 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1008612058892595e-06
+                        ]
+                    ],
+                    "values": [
+                        2.103612106729713e-06,
+                        2.070579116608684e-06,
+                        2.099095306462573e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657930.3624424934,
+                        "mem_max_rss": 14819328,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5803756999957841,
+                        "date": "2020-10-13 10:12:28.358854",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=55 C, coretemp:Core 1=40 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3436 MHz; 1=3369 MHz; 2=3344 MHz; 3=3367 MHz; 4=3485 MHz; 5=3409 MHz; 6=3349 MHz; 7=3395 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.11589735421569e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1142056580991664e-06,
+                        2.0864522554120413e-06,
+                        2.090330291970588e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657931.0067374706,
+                        "mem_max_rss": 14782464,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5828264890005812,
+                        "date": "2020-10-13 10:12:29.002709",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=55 C, coretemp:Core 1=40 C, coretemp:Core 2=42 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3407 MHz; 1=3377 MHz; 2=3354 MHz; 3=3370 MHz; 4=3486 MHz; 5=3382 MHz; 6=3372 MHz; 7=3388 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1936601561911573e-06
+                        ]
+                    ],
+                    "values": [
+                        2.108839141978791e-06,
+                        2.1176209412665514e-06,
+                        2.1406796415490703e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657931.6612038612,
+                        "mem_max_rss": 14893056,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5929121689987369,
+                        "date": "2020-10-13 10:12:29.657448",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=42 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3316 MHz; 1=3464 MHz; 2=3378 MHz; 3=3309 MHz; 4=3387 MHz; 5=3354 MHz; 6=3375 MHz; 7=3325 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1033323513997004e-06
+                        ]
+                    ],
+                    "values": [
+                        2.092377609397289e-06,
+                        2.119704773040354e-06,
+                        2.1517429962258916e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657932.3098025322,
+                        "mem_max_rss": 14753792,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.586522742989473,
+                        "date": "2020-10-13 10:12:30.306051",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=42 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3343 MHz; 1=3473 MHz; 2=3353 MHz; 3=3345 MHz; 4=3360 MHz; 5=3476 MHz; 6=3379 MHz; 7=3334 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.156569351097204e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0982786561596356e-06,
+                        2.085403030260835e-06,
+                        2.095573714999688e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657932.9556074142,
+                        "mem_max_rss": 14811136,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5843749080086127,
+                        "date": "2020-10-13 10:12:30.951828",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=41 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3334 MHz; 1=3403 MHz; 2=3387 MHz; 3=3308 MHz; 4=3347 MHz; 5=3470 MHz; 6=3360 MHz; 7=3350 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.089405608973749e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0887550964410195e-06,
+                        2.1265024261474252e-06,
+                        2.117987243810404e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657933.5998132229,
+                        "mem_max_rss": 14790656,
+                        "load_avg_1min": 0.53,
+                        "duration": 0.5831602170073893,
+                        "date": "2020-10-13 10:12:31.596194",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=41 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0,3=3345 MHz; 1=3354 MHz; 2=3374 MHz; 4=3355 MHz; 5=3472 MHz; 6=3364 MHz; 7=3343 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0774856261951413e-06
+                        ]
+                    ],
+                    "values": [
+                        2.050876358072884e-06,
+                        2.1184311367328235e-06,
+                        2.0888911591576687e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657934.2389497757,
+                        "mem_max_rss": 14909440,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5778393450018484,
+                        "date": "2020-10-13 10:12:32.235263",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=41 C, coretemp:Core 1=55 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3358 MHz; 1=3397 MHz; 2=3383 MHz; 3=3372 MHz; 4=3376 MHz; 5=3482 MHz; 6=3364 MHz; 7=3347 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0994500120607995e-06
+                        ]
+                    ],
+                    "values": [
+                        2.115163406646303e-06,
+                        2.097081741592177e-06,
+                        2.082702987848961e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657934.8827722073,
+                        "mem_max_rss": 14807040,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5816990919993259,
+                        "date": "2020-10-13 10:12:32.878941",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=41 C, coretemp:Core 1=55 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3340 MHz; 1=3383 MHz; 2=3387 MHz; 3=3370 MHz; 4=3375 MHz; 5=3481 MHz; 6=3357 MHz; 7=3343 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1089848938338207e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1217475434376354e-06,
+                        2.0873822630385064e-06,
+                        2.1301250607841382e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657935.5297029018,
+                        "mem_max_rss": 14790656,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5857305440003984,
+                        "date": "2020-10-13 10:12:33.525887",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=42 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3343 MHz; 1=3376 MHz; 2,4,6=3375 MHz; 3=3359 MHz; 5=3484 MHz; 7=3335 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1]*1000'",
+                "runnable_threads": 1,
+                "name": "[1]*1000",
+                "loops": 64,
+                "tags": [
+                    "foo"
+                ]
+            }
+        },
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            3.712099612585007e-06
+                        ],
+                        [
+                            2,
+                            5.504616694906872e-06
+                        ],
+                        [
+                            4,
+                            3.943752687973756e-06
+                        ],
+                        [
+                            8,
+                            3.7765255136434916e-06
+                        ],
+                        [
+                            16,
+                            4.012903868755302e-06
+                        ],
+                        [
+                            32,
+                            3.7361303713012717e-06
+                        ],
+                        [
+                            32,
+                            3.5964451603476277e-06
+                        ],
+                        [
+                            32,
+                            3.5878436586145313e-06
+                        ],
+                        [
+                            32,
+                            3.798480102013002e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 657936.2786154747,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15437824,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.6708496829960495,
+                        "date": "2020-10-13 10:12:34.274909",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=42 C, coretemp:Core 1=54 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3273 MHz; 1=3357 MHz; 2=3356 MHz; 3=3247 MHz; 4=3284 MHz; 5=3458 MHz; 6=3311 MHz; 7=3252 MHz",
+                        "calibrate_loops": 32
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.7744809873174745e-06
+                        ]
+                    ],
+                    "values": [
+                        3.669329223576767e-06,
+                        3.6715540465692698e-06,
+                        3.698872771629169e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657936.865452528,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15441920,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5227843550092075,
+                        "date": "2020-10-13 10:12:34.861696",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=42 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3342 MHz; 1=3341 MHz; 2=3361 MHz; 3=3338 MHz; 4=3319 MHz; 5=3467 MHz; 6=3357 MHz; 7=3326 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.8032444766855633e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6657483208912822e-06,
+                        3.702061400545631e-06,
+                        3.6906846920814473e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657937.4530115128,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15589376,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5240018159965985,
+                        "date": "2020-10-13 10:12:35.449301",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=42 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3358 MHz; 1=3472 MHz; 2=3376 MHz; 3=3365 MHz; 4=3361 MHz; 5=3463 MHz; 6=3350 MHz; 7=3334 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.77383242788909e-06
+                        ]
+                    ],
+                    "values": [
+                        3.768777618873287e-06,
+                        3.702334778310501e-06,
+                        3.74974118066973e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657938.0449326038,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15458304,
+                        "load_avg_1min": 0.57,
+                        "duration": 0.5283373990096152,
+                        "date": "2020-10-13 10:12:36.041257",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3251 MHz; 1=3464 MHz; 2=3381 MHz; 3=3291 MHz; 4=3349 MHz; 5=3213 MHz; 6=3351 MHz; 7=3289 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.6774054255062083e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6594212042828644e-06,
+                        3.7017296454777693e-06,
+                        3.7554667970951527e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657938.6305115223,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15597568,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5204855719930492,
+                        "date": "2020-10-13 10:12:36.626629",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3365 MHz; 1=3478 MHz; 2,6=3377 MHz; 3=3358 MHz; 4=3366 MHz; 5=3364 MHz; 7=3316 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.705169128842556e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6464543766712154e-06,
+                        3.6581165776539137e-06,
+                        3.695156036265246e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657939.2140340805,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15466496,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5186042910208926,
+                        "date": "2020-10-13 10:12:37.210208",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3360 MHz; 1=3468 MHz; 2=3383 MHz; 3,6=3355 MHz; 4=3387 MHz; 5=3351 MHz; 7=3292 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.708815918379571e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6959594424956776e-06,
+                        3.6830237126750376e-06,
+                        3.7725497747942427e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657939.8050436974,
+                        "runnable_threads": 4,
+                        "mem_max_rss": 15491072,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5290840109810233,
+                        "date": "2020-10-13 10:12:37.800925",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3351 MHz; 1=3465 MHz; 2=3338 MHz; 3=3311 MHz; 4=3314 MHz; 5=3329 MHz; 6=3331 MHz; 7=3302 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.915213042660071e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7007331536997867e-06,
+                        3.7456993409179518e-06,
+                        3.696728302138297e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657940.4029314518,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15486976,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5314648339990526,
+                        "date": "2020-10-13 10:12:38.399244",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3331 MHz; 1=3447 MHz; 2=3305 MHz; 3=3291 MHz; 4=3289 MHz; 5=3251 MHz; 6=3268 MHz; 7=3309 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.869788849364397e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6670103149560873e-06,
+                        3.6417566215973807e-06,
+                        3.6984561768704793e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657940.9927167892,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15470592,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.525002003996633,
+                        "date": "2020-10-13 10:12:38.989065",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3334 MHz; 1=3469 MHz; 2=3347 MHz; 3=3311 MHz; 4=3336 MHz; 5=3325 MHz; 6=3273 MHz; 7=3328 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.862502532925305e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6976179504932816e-06,
+                        3.6501969296054426e-06,
+                        3.791044372647434e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657941.5867583752,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15589376,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5299231829994824,
+                        "date": "2020-10-13 10:12:39.583092",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3351 MHz; 1=3463 MHz; 2=3368 MHz; 3=3362 MHz; 4=3359 MHz; 5=3389 MHz; 6=3349 MHz; 7=3323 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.7395388794436712e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6444016107139987e-06,
+                        3.6250761104028584e-06,
+                        3.6761129145190807e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657942.1689260006,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15495168,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5177668499818537,
+                        "date": "2020-10-13 10:12:40.165223",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3348 MHz; 1=3473 MHz; 2=3382 MHz; 3=3368 MHz; 4=3343 MHz; 5=3408 MHz; 6=3352 MHz; 7=3354 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.71612115479536e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7071033629487715e-06,
+                        3.6978441473323187e-06,
+                        3.6665706177885227e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657942.7547855377,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15585280,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5217063410091214,
+                        "date": "2020-10-13 10:12:40.750999",
+                        "cpu_temp": "coretemp:Package id 0=50 C, coretemp:Core 0=42 C, coretemp:Core 1=50 C, coretemp:Core 2=42 C, coretemp:Core 3=49 C",
+                        "cpu_freq": "0=3356 MHz; 1=3474 MHz; 2=3382 MHz; 3=3378 MHz; 4=3357 MHz; 5=3405 MHz; 6=3359 MHz; 7=3346 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.7095194702629897e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7244451904783205e-06,
+                        3.7031224673356178e-06,
+                        3.672817168620668e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657943.3413484097,
+                        "runnable_threads": 3,
+                        "mem_max_rss": 15433728,
+                        "load_avg_1min": 0.6,
+                        "duration": 0.5217426200106274,
+                        "date": "2020-10-13 10:12:41.337495",
+                        "cpu_temp": "coretemp:Package id 0=50 C, coretemp:Core 0=42 C, coretemp:Core 1=50 C, coretemp:Core 2=42 C, coretemp:Core 3=49 C",
+                        "cpu_freq": "0,6=3363 MHz; 1=3397 MHz; 2=3374 MHz; 3=3431 MHz; 4=3352 MHz; 5=3476 MHz; 7=3342 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.711399627626122e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7044279785902745e-06,
+                        3.634903656291044e-06,
+                        3.721080505059149e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657943.9250047207,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15478784,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5204073289933149,
+                        "date": "2020-10-13 10:12:41.921165",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=44 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3348 MHz; 1=3405 MHz; 2=3381 MHz; 3=3371 MHz; 4=3364 MHz; 5=3472 MHz; 6=3378 MHz; 7=3318 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.786422667850786e-06
+                        ]
+                    ],
+                    "values": [
+                        3.6881658020959662e-06,
+                        3.6703562011908275e-06,
+                        3.7557925418596483e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657944.5150334835,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15507456,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5250880670209881,
+                        "date": "2020-10-13 10:12:42.511179",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=44 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3374 MHz; 1=3414 MHz; 2=3375 MHz; 3=3357 MHz; 4=3359 MHz; 5=3480 MHz; 6=3372 MHz; 7=3338 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.6709724424710544e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7660537106631864e-06,
+                        3.6874288031896185e-06,
+                        3.700652283278316e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657945.1022946835,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15638528,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5229558770079166,
+                        "date": "2020-10-13 10:12:43.098505",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3348 MHz; 1=3352 MHz; 2=3380 MHz; 3=3289 MHz; 4=3340 MHz; 5=3473 MHz; 6=3350 MHz; 7=3344 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.769944702192163e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7237010497293e-06,
+                        3.732342773510311e-06,
+                        3.813090606819003e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657945.6965875626,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15458304,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5299140000133775,
+                        "date": "2020-10-13 10:12:43.692789",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3362 MHz; 1=3408 MHz; 2=3363 MHz; 3=3350 MHz; 4=3364 MHz; 5=3473 MHz; 6=3384 MHz; 7=3333 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.7557611394234414e-06
+                        ]
+                    ],
+                    "values": [
+                        3.8140326843461025e-06,
+                        3.7504308476599135e-06,
+                        3.923302551278596e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657946.2967317104,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15572992,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.537075291009387,
+                        "date": "2020-10-13 10:12:44.292794",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3328 MHz; 1=3333 MHz; 2=3374 MHz; 3=3323 MHz; 4=3299 MHz; 5=3459 MHz; 6=3364 MHz; 7=3285 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.745684540312766e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7173206477447707e-06,
+                        3.688994445916194e-06,
+                        3.6733338006911254e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657946.8837490082,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15601664,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5225446849945001,
+                        "date": "2020-10-13 10:12:44.880080",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3368 MHz; 1=3326 MHz; 2=3362 MHz; 3=3358 MHz; 4=3349 MHz; 5=3429 MHz; 6=3473 MHz; 7=3376 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.687901794613424e-06
+                        ]
+                    ],
+                    "values": [
+                        3.683264831799704e-06,
+                        3.6678152159907995e-06,
+                        3.680074890155538e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657947.4669554234,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15454208,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5192030819889624,
+                        "date": "2020-10-13 10:12:45.463201",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=55 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3336 MHz; 1=3474 MHz; 2=3305 MHz; 3=3355 MHz; 4=3342 MHz; 5=3400 MHz; 6=3442 MHz; 7=3372 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            3.67131124878739e-06
+                        ]
+                    ],
+                    "values": [
+                        3.7145615534583953e-06,
+                        3.661985901182163e-06,
+                        3.695577545315132e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657948.0517725945,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 15536128,
+                        "load_avg_1min": 0.64,
+                        "duration": 0.5189637840085197,
+                        "date": "2020-10-13 10:12:46.048165",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=55 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3348 MHz; 1=3477 MHz; 2=3385 MHz; 3=3360 MHz; 4=3346 MHz; 5=3362 MHz; 6=3368 MHz; 7=3354 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1,2]*1000'",
+                "name": "[1,2]*1000",
+                "loops": 32,
+                "tags": ["foo", "bar"]
+            }
+        },
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            4.701474608737044e-06
+                        ],
+                        [
+                            2,
+                            4.43758789003823e-06
+                        ],
+                        [
+                            4,
+                            4.775039549542726e-06
+                        ],
+                        [
+                            8,
+                            4.6853520494494205e-06
+                        ],
+                        [
+                            16,
+                            4.7781087033627045e-06
+                        ],
+                        [
+                            32,
+                            4.958948486510906e-06
+                        ],
+                        [
+                            32,
+                            4.843608642168817e-06
+                        ],
+                        [
+                            32,
+                            4.692033416908714e-06
+                        ],
+                        [
+                            32,
+                            4.616228515885723e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 657948.9858856201,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16347136,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.848449521989096,
+                        "date": "2020-10-13 10:12:46.982099",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3334 MHz; 1=3461 MHz; 2=3324 MHz; 3=3312 MHz; 4=3375 MHz; 5=3348 MHz; 6=3337 MHz; 7=3327 MHz",
+                        "calibrate_loops": 32
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.632844970764438e-06
+                        ]
+                    ],
+                    "values": [
+                        4.54860086041009e-06,
+                        4.644940430509337e-06,
+                        4.625685730452744e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657949.7009351254,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16191488,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6466717020084616,
+                        "date": "2020-10-13 10:12:47.697172",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3351 MHz; 1=3476 MHz; 2=3323 MHz; 3=3353 MHz; 4=3364 MHz; 5=3360 MHz; 6=3398 MHz; 7=3356 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.548068512022496e-06
+                        ]
+                    ],
+                    "values": [
+                        4.540110717599077e-06,
+                        4.6062897949283865e-06,
+                        4.52680090390345e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657950.4072501659,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16216064,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6392136909998953,
+                        "date": "2020-10-13 10:12:48.403592",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3469 MHz; 1=3423 MHz; 2=3325 MHz; 3=3322 MHz; 4=3406 MHz; 5=3350 MHz; 6=3345 MHz; 7=3331 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.773690185366775e-06
+                        ]
+                    ],
+                    "values": [
+                        4.505050598346827e-06,
+                        4.611007843102755e-06,
+                        4.588196655497256e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657951.1249730587,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16207872,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6480437600112054,
+                        "date": "2020-10-13 10:12:49.121332",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3471 MHz; 1=3354 MHz; 2=3332 MHz; 3=3356 MHz; 4=3413 MHz; 5=3371 MHz; 6=3367 MHz; 7=3302 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.65421945161637e-06
+                        ]
+                    ],
+                    "values": [
+                        4.642087219508539e-06,
+                        4.584821746256296e-06,
+                        4.54914999359346e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657951.8497200012,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16273408,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6479080629942473,
+                        "date": "2020-10-13 10:12:49.846016",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3438 MHz; 1=3335 MHz; 2=3360 MHz; 3=2955 MHz; 4=3434 MHz; 5=3341 MHz; 6=3203 MHz; 7=3249 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.631759765061361e-06
+                        ]
+                    ],
+                    "values": [
+                        4.587001617650799e-06,
+                        4.546308044695024e-06,
+                        4.571820434229323e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657952.5597033501,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16302080,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6427170200040564,
+                        "date": "2020-10-13 10:12:50.556086",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3455 MHz; 1=3383 MHz; 2=3340 MHz; 3=3349 MHz; 4=3485 MHz; 5=3377 MHz; 6=3368 MHz; 7=3359 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.641498016155765e-06
+                        ]
+                    ],
+                    "values": [
+                        4.49950015291023e-06,
+                        4.625188049445228e-06,
+                        4.6076624142799005e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657953.2715580463,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16203776,
+                        "load_avg_1min": 0.67,
+                        "duration": 0.6446363200084306,
+                        "date": "2020-10-13 10:12:51.267802",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3404 MHz; 1=3390 MHz; 2-3=3370 MHz; 4=3478 MHz; 5=3358 MHz; 6=3366 MHz; 7=3336 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.67598291020721e-06
+                        ]
+                    ],
+                    "values": [
+                        4.554814728052747e-06,
+                        4.557179596353933e-06,
+                        4.543543579593745e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657953.9802863598,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16232448,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6424169829988386,
+                        "date": "2020-10-13 10:12:51.976639",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3335 MHz; 1=3383 MHz; 2=3375 MHz; 3=3325 MHz; 4=3478 MHz; 5=3346 MHz; 6=3338 MHz; 7=3315 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.518897125826982e-06
+                        ]
+                    ],
+                    "values": [
+                        4.519812713432714e-06,
+                        4.595441009058732e-06,
+                        4.5124219365533236e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657954.6824829578,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16388096,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6353659099841025,
+                        "date": "2020-10-13 10:12:52.678869",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3454 MHz; 1=3378 MHz; 2=3371 MHz; 3=3392 MHz; 4=3488 MHz; 5=3339 MHz; 6=3368 MHz; 7=3347 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.514584656334364e-06
+                        ]
+                    ],
+                    "values": [
+                        4.5583348384781175e-06,
+                        4.577305328545833e-06,
+                        4.521156524717185e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657955.3858880997,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16281600,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6368260770104825,
+                        "date": "2020-10-13 10:12:53.382144",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3454 MHz; 1=3394 MHz; 2=3383 MHz; 3=3378 MHz; 4=3491 MHz; 5=3355 MHz; 6=3368 MHz; 7=3367 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.646984558043243e-06
+                        ]
+                    ],
+                    "values": [
+                        4.531090423753881e-06,
+                        4.514837097069346e-06,
+                        4.517752411281606e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657956.090316534,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16236544,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6381545109907165,
+                        "date": "2020-10-13 10:12:54.086388",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3454 MHz; 1,3=3377 MHz; 2=3384 MHz; 4=3489 MHz; 5=3380 MHz; 6=3379 MHz; 7=3345 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.908533630221257e-06
+                        ]
+                    ],
+                    "values": [
+                        4.53745272821493e-06,
+                        4.711525970257924e-06,
+                        4.56617205824017e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657956.8134157658,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16297984,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6563077340251766,
+                        "date": "2020-10-13 10:12:54.809670",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3332 MHz; 1=3126 MHz; 2=3334 MHz; 3=3280 MHz; 4=3463 MHz; 5=3323 MHz; 6=3262 MHz; 7=3271 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.608308411313544e-06
+                        ]
+                    ],
+                    "values": [
+                        4.56174530061304e-06,
+                        4.567334412008961e-06,
+                        4.7096530755297294e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657957.5264596939,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16220160,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6453942260122858,
+                        "date": "2020-10-13 10:12:55.522858",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3482 MHz; 1=3383 MHz; 2=3358 MHz; 3=3350 MHz; 4=3461 MHz; 5=3385 MHz; 6=3341 MHz; 7=3346 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.607640350151598e-06
+                        ]
+                    ],
+                    "values": [
+                        4.554083344210369e-06,
+                        4.6013543091305564e-06,
+                        4.554704925219255e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657958.2369372845,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16392192,
+                        "load_avg_1min": 0.69,
+                        "duration": 0.6422680480172858,
+                        "date": "2020-10-13 10:12:56.233286",
+                        "cpu_temp": "coretemp:Package id 0=58 C, coretemp:Core 0=58 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3480 MHz; 1=3366 MHz; 2=3355 MHz; 3=3362 MHz; 4=3404 MHz; 5=3381 MHz; 6=3377 MHz; 7=3357 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.563380707089948e-06
+                        ]
+                    ],
+                    "values": [
+                        4.605240478738892e-06,
+                        4.606023041198171e-06,
+                        4.515203857025085e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657958.9458432198,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16248832,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6420467860007193,
+                        "date": "2020-10-13 10:12:56.941964",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3483 MHz; 1=3391 MHz; 2=3365 MHz; 3=3354 MHz; 4=3428 MHz; 5=3373 MHz; 6=3368 MHz; 7=3340 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.6269779971908065e-06
+                        ]
+                    ],
+                    "values": [
+                        4.679724395550977e-06,
+                        4.617891814717723e-06,
+                        4.671526153465777e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657959.6657063961,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16211968,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6517380950099323,
+                        "date": "2020-10-13 10:12:57.662086",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3484 MHz; 1=3351 MHz; 2=3355 MHz; 3=3354 MHz; 4=3343 MHz; 5=3379 MHz; 6=3362 MHz; 7=3319 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.646165526978052e-06
+                        ]
+                    ],
+                    "values": [
+                        4.527052094083217e-06,
+                        4.60910824617855e-06,
+                        4.5267167054774404e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657960.3754293919,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16216064,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6420106389850844,
+                        "date": "2020-10-13 10:12:58.371777",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3481 MHz; 1=3374 MHz; 2=3366 MHz; 3=3338 MHz; 4=3397 MHz; 5=3381 MHz; 6=3364 MHz; 7=3345 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.760863311581431e-06
+                        ]
+                    ],
+                    "values": [
+                        4.599784576342358e-06,
+                        4.577325714016922e-06,
+                        4.578420776724101e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657961.092704773,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16306176,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6496195569925476,
+                        "date": "2020-10-13 10:12:59.088941",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3479 MHz; 1=3377 MHz; 2=3360 MHz; 3=3368 MHz; 4=3423 MHz; 5=3378 MHz; 6=3366 MHz; 7=3342 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.354211975117096e-06
+                        ]
+                    ],
+                    "values": [
+                        4.62711911008995e-06,
+                        4.684241302399528e-06,
+                        4.5871093750093905e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657961.8378267288,
+                        "runnable_threads": 3,
+                        "mem_max_rss": 16224256,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6776227349764667,
+                        "date": "2020-10-13 10:12:59.833756",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=45 C, coretemp:Core 2=46 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3417 MHz; 1,5=3003 MHz; 2=3269 MHz; 3=3091 MHz; 4=2779 MHz; 6=3302 MHz; 7=3206 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.066545349485807e-06
+                        ]
+                    ],
+                    "values": [
+                        4.937812987826362e-06,
+                        4.7692646791830384e-06,
+                        4.719551971454905e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657962.6043066978,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16293888,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6841306230053306,
+                        "date": "2020-10-13 10:13:00.600573",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=45 C, coretemp:Core 2=46 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3367 MHz; 1=3245 MHz; 2=3332 MHz; 3=3214 MHz; 4=3237 MHz; 5=3243 MHz; 6=3159 MHz; 7=3145 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            4.7146743167303384e-06
+                        ]
+                    ],
+                    "values": [
+                        4.651347350836943e-06,
+                        5.201161071610727e-06,
+                        5.22639044220341e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657963.3686769009,
+                        "runnable_threads": 4,
+                        "mem_max_rss": 16175104,
+                        "load_avg_1min": 0.72,
+                        "duration": 0.6973627189872786,
+                        "date": "2020-10-13 10:13:01.364982",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=45 C",
+                        "cpu_freq": "0=3343 MHz; 1=3244 MHz; 2=3256 MHz; 3=3147 MHz; 4=3076 MHz; 5=3180 MHz; 6=3245 MHz; 7=3255 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1,2,3]*1000'",
+                "name": "[1,2,3]*1000",
+                "loops": 32,
+                "tags": ["bar"]
+            }
+        }
+    ]
+}

--- a/pyperf/tests/mult_list_py37_tags.json
+++ b/pyperf/tests/mult_list_py37_tags.json
@@ -1,0 +1,1575 @@
+{
+    "version": "1.0",
+    "metadata": {
+        "unit": "second",
+        "timer": "clock_gettime(CLOCK_MONOTONIC), resolution: 1.00 ns",
+        "timeit_teardown": "'pass'",
+        "timeit_setup": "'pass'",
+        "timeit_duplicate": 1024,
+        "python_version": "3.7.9 (64-bit)",
+        "python_implementation": "cpython",
+        "python_executable": "/usr/bin/python3.7",
+        "python_compiler": "GCC 10.2.1 20200723 (Red Hat 10.2.1-1)",
+        "python_cflags": "-Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv",
+        "platform": "Linux-5.8.12-200.fc32.x86_64-x86_64-with-fedora-32-Thirty_Two",
+        "perf_version": "2.0.1",
+        "inner_loops": 1024,
+        "hostname": "apu",
+        "cpu_model_name": "Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz",
+        "cpu_count": 8,
+        "cpu_config": "0-7=driver:intel_pstate, intel_pstate:turbo, governor:powersave; idle:intel_idle",
+        "boot_time": "2020-10-05 19:26:58",
+        "aslr": "Full randomization"
+    },
+    "benchmarks": [
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            2.138898423709179e-06
+                        ],
+                        [
+                            2,
+                            2.170003895685113e-06
+                        ],
+                        [
+                            4,
+                            2.03761425865423e-06
+                        ],
+                        [
+                            8,
+                            2.061924316620889e-06
+                        ],
+                        [
+                            16,
+                            2.013571167580608e-06
+                        ],
+                        [
+                            32,
+                            2.1944852290900485e-06
+                        ],
+                        [
+                            64,
+                            2.1354929349293172e-06
+                        ],
+                        [
+                            64,
+                            2.1234464568919975e-06
+                        ],
+                        [
+                            64,
+                            2.1394864653245804e-06
+                        ],
+                        [
+                            64,
+                            2.104063888452856e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 657987.9685475826,
+                        "runnable_threads": 2,
+                        "mem_max_rss": 14893056,
+                        "load_avg_1min": 0.59,
+                        "duration": 0.7605225339939352,
+                        "date": "2020-10-13 10:13:25.965067",
+                        "cpu_temp": "coretemp:Package id 0=48 C, coretemp:Core 0=39 C, coretemp:Core 1=40 C, coretemp:Core 2=40 C, coretemp:Core 3=48 C",
+                        "cpu_freq": "0=3302 MHz; 1=3300 MHz; 2=3350 MHz; 3=3395 MHz; 4=3385 MHz; 5=3462 MHz; 6=3311 MHz; 7=3355 MHz",
+                        "calibrate_loops": 64
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1381421353439123e-06
+                        ]
+                    ],
+                    "values": [
+                        2.080216247701827e-06,
+                        2.0854013977888997e-06,
+                        2.110532821841815e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657988.6221299171,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14655488,
+                        "load_avg_1min": 0.59,
+                        "duration": 0.5851852119958494,
+                        "date": "2020-10-13 10:13:26.618713",
+                        "cpu_temp": "coretemp:Package id 0=48 C, coretemp:Core 0=39 C, coretemp:Core 1=40 C, coretemp:Core 2=40 C, coretemp:Core 3=48 C",
+                        "cpu_freq": "0=3354 MHz; 1=3350 MHz; 2=3367 MHz; 3=3404 MHz; 4=3361 MHz; 5=3343 MHz; 6=3319 MHz; 7=3473 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.176670928832891e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1889022980836614e-06,
+                        2.215203506406027e-06,
+                        2.0627357635305543e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657989.274137497,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14860288,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5990613690228201,
+                        "date": "2020-10-13 10:13:27.270784",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=41 C, coretemp:Core 2=42 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3299 MHz; 1=3336 MHz; 2=3337 MHz; 3=3300 MHz; 4=3340 MHz; 5=3294 MHz; 6=3289 MHz; 7=3464 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.100071380350954e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1572226716060072e-06,
+                        2.073325836349227e-06,
+                        2.0950281527376546e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657989.913230896,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14667776,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5838392000005115,
+                        "date": "2020-10-13 10:13:27.909867",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=41 C, coretemp:Core 2=42 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3328 MHz; 1,6=3326 MHz; 2=3362 MHz; 3=3417 MHz; 4=3360 MHz; 5=3331 MHz; 7=3474 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1031545256455786e-06
+                        ]
+                    ],
+                    "values": [
+                        2.117521789468668e-06,
+                        2.0282418975448024e-06,
+                        2.05077629056305e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657990.5411837101,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14630912,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5757386459736153,
+                        "date": "2020-10-13 10:13:28.537781",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=41 C, coretemp:Core 2=43 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3375 MHz; 1,6=3345 MHz; 2=3333 MHz; 3=3403 MHz; 4=3350 MHz; 5=3344 MHz; 7=3474 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1396193239375805e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1258523865697043e-06,
+                        2.047917999181692e-06,
+                        2.0854896543021084e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657991.1879477501,
+                        "runnable_threads": 2,
+                        "mem_max_rss": 14807040,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5961460139951669,
+                        "date": "2020-10-13 10:13:29.182893",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=41 C, coretemp:Core 2=43 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3316 MHz; 1=3298 MHz; 2=3333 MHz; 3=3404 MHz; 4=3335 MHz; 5=3326 MHz; 6=3331 MHz; 7=3467 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1535711365316956e-06
+                        ]
+                    ],
+                    "values": [
+                        2.106787964084589e-06,
+                        2.0759258574365447e-06,
+                        2.0708466337282516e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657991.8405790329,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14647296,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5844863340025768,
+                        "date": "2020-10-13 10:13:29.837221",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=42 C, coretemp:Core 2=43 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=2926 MHz; 1=3002 MHz; 2=3054 MHz; 3=3042 MHz; 4=3003 MHz; 5=3112 MHz; 6=3253 MHz; 7=3405 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1358719024533457e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1158985745728387e-06,
+                        2.0638733979616575e-06,
+                        2.076777099624394e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657992.4773106575,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14688256,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.582695863005938,
+                        "date": "2020-10-13 10:13:30.474027",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=42 C, coretemp:Core 2=43 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3342 MHz; 1=3329 MHz; 2=3303 MHz; 3=3480 MHz; 4=3325 MHz; 5=3353 MHz; 6=3340 MHz; 7=3465 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1827128451334943e-06
+                        ]
+                    ],
+                    "values": [
+                        2.12266090393598e-06,
+                        2.05462533564571e-06,
+                        2.094395843421637e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657993.1200757027,
+                        "runnable_threads": 2,
+                        "mem_max_rss": 14696448,
+                        "load_avg_1min": 0.62,
+                        "duration": 0.5878902859985828,
+                        "date": "2020-10-13 10:13:31.116122",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=42 C, coretemp:Core 2=43 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3343 MHz; 1=3347 MHz; 2=3317 MHz; 3=3292 MHz; 4=3307 MHz; 5=3338 MHz; 6=3383 MHz; 7=3463 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.089770263502544e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0645877838454396e-06,
+                        2.0983376769478923e-06,
+                        2.0764185180155437e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657993.752177,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14626816,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5787410060002003,
+                        "date": "2020-10-13 10:13:31.748763",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=41 C, coretemp:Core 1=42 C, coretemp:Core 2=43 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3333 MHz; 1=3351 MHz; 2=3305 MHz; 3=3464 MHz; 4=3309 MHz; 5=3354 MHz; 6=3367 MHz; 7=3447 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0821316835117898e-06
+                        ]
+                    ],
+                    "values": [
+                        2.126313888961562e-06,
+                        2.053201888951861e-06,
+                        2.0540183411910107e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657994.3836824894,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14684160,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5778932249813806,
+                        "date": "2020-10-13 10:13:32.380254",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=42 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3359 MHz; 1,6=3340 MHz; 2=3295 MHz; 3=3468 MHz; 4=3342 MHz; 5=3338 MHz; 7=3336 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1277746276027187e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0802475431125345e-06,
+                        2.0684387358471668e-06,
+                        2.1255913238427127e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657995.0201976299,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14848000,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5827630250132643,
+                        "date": "2020-10-13 10:13:33.016847",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=42 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3313 MHz; 1=3346 MHz; 2=3309 MHz; 3=3465 MHz; 4=3373 MHz; 5=3343 MHz; 6=3324 MHz; 7=3428 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1107385865803963e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0842839965062865e-06,
+                        2.0401739964093224e-06,
+                        2.145225051819466e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657995.6540267467,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14635008,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5813000060152262,
+                        "date": "2020-10-13 10:13:33.650663",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=42 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3353 MHz; 1,5=3336 MHz; 2=3343 MHz; 3=3471 MHz; 4=3390 MHz; 6=3365 MHz; 7=3333 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.10850292958753e-06
+                        ]
+                    ],
+                    "values": [
+                        2.100832367180061e-06,
+                        2.1030137484778777e-06,
+                        2.1844230957412947e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657996.2977519035,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14860288,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5896678050048649,
+                        "date": "2020-10-13 10:13:34.294150",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=42 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3327 MHz; 1=3374 MHz; 2=3323 MHz; 3=3455 MHz; 4=3336 MHz; 5=3345 MHz; 6=3299 MHz; 7=3469 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1095587769970336e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1019816589529228e-06,
+                        2.085441604293692e-06,
+                        2.066215408547123e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657996.9310235977,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14643200,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5806322369899135,
+                        "date": "2020-10-13 10:13:34.927449",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3363 MHz; 1=3323 MHz; 2=3360 MHz; 3=3471 MHz; 4=3366 MHz; 5=3344 MHz; 6=3345 MHz; 7=3365 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1312981721699487e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0945771788127843e-06,
+                        2.0817479859935872e-06,
+                        2.0762981871591535e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657997.5664095879,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14663680,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5823150069918483,
+                        "date": "2020-10-13 10:13:35.563071",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3340 MHz; 1=3352 MHz; 2=3319 MHz; 3=3468 MHz; 4=3373 MHz; 5=3321 MHz; 6=3345 MHz; 7=3299 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1036983031130774e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0958032838080953e-06,
+                        2.0984022368608635e-06,
+                        2.079317443559603e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657998.2014124393,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14663680,
+                        "load_avg_1min": 0.66,
+                        "duration": 0.5817205070052296,
+                        "date": "2020-10-13 10:13:36.198097",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=42 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3322 MHz; 1=3307 MHz; 2=3334 MHz; 3=3463 MHz; 4=3390 MHz; 5=3358 MHz; 6=3297 MHz; 7=3391 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.109872772493304e-06
+                        ]
+                    ],
+                    "values": [
+                        2.1210172422847506e-06,
+                        2.0518668670810314e-06,
+                        2.113285156202238e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657998.8384315968,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14704640,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.5834881540213246,
+                        "date": "2020-10-13 10:13:36.834750",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=42 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3358 MHz; 1=3359 MHz; 2=3351 MHz; 3=3469 MHz; 4=3346 MHz; 5=3338 MHz; 6=3366 MHz; 7=3406 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.088366836350275e-06
+                        ]
+                    ],
+                    "values": [
+                        2.079300186252908e-06,
+                        2.03466526782492e-06,
+                        2.0388919068636824e-06
+                    ],
+                    "metadata": {
+                        "uptime": 657999.4631211758,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14864384,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.57200685000862,
+                        "date": "2020-10-13 10:13:37.459627",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=43 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3363 MHz; 1=3307 MHz; 2=3309 MHz; 3=3467 MHz; 4=3355 MHz; 5=3328 MHz; 6=3298 MHz; 7=3396 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.1271123813448867e-06
+                        ]
+                    ],
+                    "values": [
+                        2.0711766204328796e-06,
+                        2.0339705808503084e-06,
+                        2.082836929151455e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658000.0933566093,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14667776,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.5775346280133817,
+                        "date": "2020-10-13 10:13:38.089907",
+                        "cpu_temp": "coretemp:Package id 0=60 C, coretemp:Core 0=43 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=60 C",
+                        "cpu_freq": "0=3373 MHz; 1=3372 MHz; 2,4=3359 MHz; 3=3478 MHz; 5=3361 MHz; 6=3368 MHz; 7=3423 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            64,
+                            2.0946143490796487e-06
+                        ]
+                    ],
+                    "values": [
+                        2.069512359259562e-06,
+                        2.0773010862562558e-06,
+                        2.114736587621735e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658000.7260615826,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 14630912,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.5799994990229607,
+                        "date": "2020-10-13 10:13:38.722556",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3352 MHz; 1=3378 MHz; 2=3363 MHz; 3=3481 MHz; 4=3370 MHz; 5=3317 MHz; 6=3362 MHz; 7=3403 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1]*1000'",
+                "name": "[1]*1000",
+                "loops": 64,
+                "tags": [
+                    "foo"
+                ]
+            }
+        },
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            5.52950291421439e-06
+                        ],
+                        [
+                            2,
+                            5.2768090768040565e-06
+                        ],
+                        [
+                            4,
+                            5.1085246539628315e-06
+                        ],
+                        [
+                            8,
+                            5.173984863660053e-06
+                        ],
+                        [
+                            16,
+                            5.1956826787602495e-06
+                        ],
+                        [
+                            32,
+                            5.196582184119336e-06
+                        ],
+                        [
+                            32,
+                            5.4228958132895855e-06
+                        ],
+                        [
+                            32,
+                            5.206513488786868e-06
+                        ],
+                        [
+                            32,
+                            5.2832040102757105e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 658001.7122936249,
+                        "mem_max_rss": 16175104,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.918149937002454,
+                        "date": "2020-10-13 10:13:39.708767",
+                        "cpu_temp": "coretemp:Package id 0=59 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=59 C",
+                        "cpu_freq": "0=3349 MHz; 1=3382 MHz; 2=3402 MHz; 3=3478 MHz; 4=3367 MHz; 5=3355 MHz; 6=3361 MHz; 7=3405 MHz",
+                        "calibrate_loops": 32
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.373522613538739e-06
+                        ]
+                    ],
+                    "values": [
+                        5.495433288871254e-06,
+                        5.363710570804869e-06,
+                        5.270519500832904e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658002.5106654167,
+                        "mem_max_rss": 15941632,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.7431029989966191,
+                        "date": "2020-10-13 10:13:40.507020",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=42 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3298 MHz; 1=3317 MHz; 2=3277 MHz; 3=3469 MHz; 4=3288 MHz; 5=3303 MHz; 6=3281 MHz; 7=3391 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.37625555363519e-06
+                        ]
+                    ],
+                    "values": [
+                        5.193778900292045e-06,
+                        5.305556671331146e-06,
+                        5.224747650522943e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658003.2967464924,
+                        "mem_max_rss": 15982592,
+                        "load_avg_1min": 0.68,
+                        "duration": 0.728768144006608,
+                        "date": "2020-10-13 10:13:41.293402",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=42 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3468 MHz; 1=3349 MHz; 2=3348 MHz; 3=3464 MHz; 4=3435 MHz; 5=3344 MHz; 6=3288 MHz; 7=3313 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.390015838102613e-06
+                        ]
+                    ],
+                    "values": [
+                        5.316876830363526e-06,
+                        5.2398487246918535e-06,
+                        5.267025725785857e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658004.0869870186,
+                        "mem_max_rss": 15978496,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.7334089789947029,
+                        "date": "2020-10-13 10:13:42.083658",
+                        "cpu_temp": "coretemp:Package id 0=62 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=62 C",
+                        "cpu_freq": "0=3449 MHz; 1-2,4=3371 MHz; 3=3482 MHz; 5=3345 MHz; 6=3362 MHz; 7=3425 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.391778502783495e-06
+                        ]
+                    ],
+                    "values": [
+                        5.191289917050312e-06,
+                        5.296789795217194e-06,
+                        5.217660644873945e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658004.872289896,
+                        "mem_max_rss": 15904768,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.7288176910078619,
+                        "date": "2020-10-13 10:13:42.868840",
+                        "cpu_temp": "coretemp:Package id 0=62 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=62 C",
+                        "cpu_freq": "0=3371 MHz; 1=3328 MHz; 2=3379 MHz; 3=3481 MHz; 4=3374 MHz; 5=3368 MHz; 6=3373 MHz; 7=3433 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.3487924498440975e-06
+                        ]
+                    ],
+                    "values": [
+                        5.272262786348847e-06,
+                        5.2605756222234845e-06,
+                        5.381430786322028e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658005.6624557972,
+                        "mem_max_rss": 15925248,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.7343786599813029,
+                        "date": "2020-10-13 10:13:43.659108",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3375 MHz; 1=3335 MHz; 2=3369 MHz; 3=3477 MHz; 4=3372 MHz; 5=3357 MHz; 6=3321 MHz; 7=3418 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.34880130054205e-06
+                        ]
+                    ],
+                    "values": [
+                        5.291179015820546e-06,
+                        5.469558166382171e-06,
+                        5.2268379517883545e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658006.4562153816,
+                        "mem_max_rss": 15978496,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.7368686879926827,
+                        "date": "2020-10-13 10:13:44.452841",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3355 MHz; 1=3373 MHz; 2=3320 MHz; 3=3470 MHz; 4=3344 MHz; 5=3348 MHz; 6=3341 MHz; 7=3385 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.479334106439637e-06
+                        ]
+                    ],
+                    "values": [
+                        5.193132599501382e-06,
+                        5.237599823182393e-06,
+                        5.1962203979627475e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658007.240385294,
+                        "mem_max_rss": 16113664,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.728775344992755,
+                        "date": "2020-10-13 10:13:45.237005",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3354 MHz; 1=3339 MHz; 2=3347 MHz; 3=3470 MHz; 4=3364 MHz; 5=3344 MHz; 6=3311 MHz; 7=3367 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.3678695683956335e-06
+                        ]
+                    ],
+                    "values": [
+                        5.483771393421932e-06,
+                        5.519388641239686e-06,
+                        5.582461792386084e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658008.0550892353,
+                        "mem_max_rss": 15978496,
+                        "load_avg_1min": 0.71,
+                        "duration": 0.7581673340173438,
+                        "date": "2020-10-13 10:13:46.051583",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0,7=3369 MHz; 1=3334 MHz; 2=3370 MHz; 3=3453 MHz; 4=3348 MHz; 5=3319 MHz; 6=3337 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.79857479809931e-06
+                        ]
+                    ],
+                    "values": [
+                        5.2859132075866455e-06,
+                        5.251718109278158e-06,
+                        5.223639067963859e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658008.8571527004,
+                        "mem_max_rss": 15937536,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7457811390049756,
+                        "date": "2020-10-13 10:13:46.853786",
+                        "cpu_temp": "coretemp:Package id 0=62 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3359 MHz; 1-2=3358 MHz; 3=3455 MHz; 4=3337 MHz; 5=3356 MHz; 6=3372 MHz; 7=3382 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.390363372548279e-06
+                        ]
+                    ],
+                    "values": [
+                        5.226751983222755e-06,
+                        5.213244110180426e-06,
+                        5.2470726625841735e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658009.6406047344,
+                        "mem_max_rss": 15974400,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7280215510108974,
+                        "date": "2020-10-13 10:13:47.637210",
+                        "cpu_temp": "coretemp:Package id 0=62 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3374 MHz; 1=3373 MHz; 2=3359 MHz; 3=3484 MHz; 4=3343 MHz; 5=3356 MHz; 6=3329 MHz; 7=3377 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.483001068284921e-06
+                        ]
+                    ],
+                    "values": [
+                        5.207024933007176e-06,
+                        5.231227570234864e-06,
+                        5.2346267089831144e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658010.427624464,
+                        "mem_max_rss": 15958016,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7312444800045341,
+                        "date": "2020-10-13 10:13:48.424244",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=44 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3361 MHz; 1=3352 MHz; 2=3350 MHz; 3=3480 MHz; 4=3369 MHz; 5=3342 MHz; 6=3323 MHz; 7=3367 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.5024282836768634e-06
+                        ]
+                    ],
+                    "values": [
+                        5.2077980656761724e-06,
+                        5.211723754783293e-06,
+                        5.37395303368271e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658011.2196595669,
+                        "mem_max_rss": 16150528,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7361323869845364,
+                        "date": "2020-10-13 10:13:49.216232",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=44 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3324 MHz; 1=3376 MHz; 2=3371 MHz; 3=3477 MHz; 4=3358 MHz; 5=3365 MHz; 6=3346 MHz; 7=3374 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.3919135734048496e-06
+                        ]
+                    ],
+                    "values": [
+                        5.251146546036978e-06,
+                        5.270013549996122e-06,
+                        5.189221465862204e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658012.0038564205,
+                        "mem_max_rss": 15912960,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7290913229808211,
+                        "date": "2020-10-13 10:13:50.000431",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=55 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3487 MHz; 1=3370 MHz; 2=3322 MHz; 3=3460 MHz; 4=3347 MHz; 5=3330 MHz; 6=3317 MHz; 7=3366 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.32899993910263e-06
+                        ]
+                    ],
+                    "values": [
+                        5.236789031748401e-06,
+                        5.285047454783864e-06,
+                        5.277883758481039e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658012.7913990021,
+                        "mem_max_rss": 16113664,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7301619569770992,
+                        "date": "2020-10-13 10:13:50.788137",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=55 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3409 MHz; 1=3362 MHz; 2=3323 MHz; 3=3471 MHz; 4=3359 MHz; 5=3300 MHz; 6=3331 MHz; 7=3372 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.344810668717059e-06
+                        ]
+                    ],
+                    "values": [
+                        5.256270324771606e-06,
+                        5.205607116920419e-06,
+                        5.32024646027196e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658013.575811863,
+                        "mem_max_rss": 16097280,
+                        "load_avg_1min": 0.73,
+                        "duration": 0.7299452160077635,
+                        "date": "2020-10-13 10:13:51.572438",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0,6=3344 MHz; 1=3296 MHz; 2=3260 MHz; 3=3477 MHz; 4=3373 MHz; 5=3341 MHz; 7=3325 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.406503692739761e-06
+                        ]
+                    ],
+                    "values": [
+                        5.241663574295785e-06,
+                        5.182055084596016e-06,
+                        5.174474700275766e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658014.3571565151,
+                        "mem_max_rss": 16150528,
+                        "load_avg_1min": 0.83,
+                        "duration": 0.7254772470041644,
+                        "date": "2020-10-13 10:13:52.353857",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3346 MHz; 1=3339 MHz; 2=3389 MHz; 3=3482 MHz; 4=3382 MHz; 5=3356 MHz; 6=3353 MHz; 7=3373 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.460321289341152e-06
+                        ]
+                    ],
+                    "values": [
+                        5.213108734025695e-06,
+                        5.3393807366575174e-06,
+                        5.315948242490265e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658015.1494317055,
+                        "mem_max_rss": 16125952,
+                        "load_avg_1min": 0.83,
+                        "duration": 0.7362742499972228,
+                        "date": "2020-10-13 10:13:53.145939",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0,4=3359 MHz; 1=3308 MHz; 2=3340 MHz; 3=3474 MHz; 5=3329 MHz; 6=3347 MHz; 7=3342 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.4411842036472535e-06
+                        ]
+                    ],
+                    "values": [
+                        5.4401580200647e-06,
+                        5.3370979919975525e-06,
+                        5.208466583361826e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658015.9448275566,
+                        "mem_max_rss": 15945728,
+                        "load_avg_1min": 0.83,
+                        "duration": 0.7404681489861105,
+                        "date": "2020-10-13 10:13:53.941409",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3355 MHz; 1=3268 MHz; 2=3337 MHz; 3=3469 MHz; 4=3312 MHz; 5=3363 MHz; 6=3345 MHz; 7=3378 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.469982330197354e-06
+                        ]
+                    ],
+                    "values": [
+                        5.355075195723202e-06,
+                        5.241574859482512e-06,
+                        5.250668030143402e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658016.7400181293,
+                        "mem_max_rss": 16261120,
+                        "load_avg_1min": 0.83,
+                        "duration": 0.7398925239976961,
+                        "date": "2020-10-13 10:13:54.736693",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3361 MHz; 1=3309 MHz; 2=3354 MHz; 3=3466 MHz; 4=3331 MHz; 5=3348 MHz; 6=3341 MHz; 7=3393 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.409230407593668e-06
+                        ]
+                    ],
+                    "values": [
+                        5.202141998061904e-06,
+                        5.1866737971195676e-06,
+                        5.233533690862657e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658017.5223152637,
+                        "mem_max_rss": 16146432,
+                        "load_avg_1min": 0.83,
+                        "duration": 0.726997312012827,
+                        "date": "2020-10-13 10:13:55.518974",
+                        "cpu_temp": "coretemp:Package id 0=61 C, coretemp:Core 0=43 C, coretemp:Core 1=43 C, coretemp:Core 2=44 C, coretemp:Core 3=61 C",
+                        "cpu_freq": "0=3343 MHz; 1=3476 MHz; 2=3363 MHz; 3=3453 MHz; 4=3354 MHz; 5=3414 MHz; 6=3344 MHz; 7=3374 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1,2]*1000'",
+                "runnable_threads": 1,
+                "name": "[1,2]*1000",
+                "loops": 32,
+                "tags": ["foo", "bar"]
+            }
+        },
+        {
+            "runs": [
+                {
+                    "warmups": [
+                        [
+                            1,
+                            6.3204082039192144e-06
+                        ],
+                        [
+                            2,
+                            6.14726756964501e-06
+                        ],
+                        [
+                            4,
+                            6.045642088281511e-06
+                        ],
+                        [
+                            8,
+                            5.9721135272639e-06
+                        ],
+                        [
+                            16,
+                            6.088329712383711e-06
+                        ],
+                        [
+                            32,
+                            5.990041504588817e-06
+                        ],
+                        [
+                            32,
+                            6.036955138455369e-06
+                        ],
+                        [
+                            32,
+                            5.9912289733787816e-06
+                        ],
+                        [
+                            32,
+                            6.049253082451855e-06
+                        ]
+                    ],
+                    "metadata": {
+                        "uptime": 658018.6589839458,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17149952,
+                        "load_avg_1min": 0.85,
+                        "duration": 1.0691963550052606,
+                        "date": "2020-10-13 10:13:56.655468",
+                        "cpu_temp": "coretemp:Package id 0=48 C, coretemp:Core 0=41 C, coretemp:Core 1=48 C, coretemp:Core 2=41 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3340 MHz; 1=3300 MHz; 2=3400 MHz; 3=3276 MHz; 4=3386 MHz; 5=3378 MHz; 6=3318 MHz; 7=3473 MHz",
+                        "calibrate_loops": 32
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.061434723036996e-06
+                        ]
+                    ],
+                    "values": [
+                        6.136977081183659e-06,
+                        6.02163729901406e-06,
+                        6.020176726906357e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658019.5671598911,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16830464,
+                        "load_avg_1min": 0.85,
+                        "duration": 0.8382125339994673,
+                        "date": "2020-10-13 10:13:57.563759",
+                        "cpu_temp": "coretemp:Package id 0=48 C, coretemp:Core 0=41 C, coretemp:Core 1=48 C, coretemp:Core 2=41 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3362 MHz; 1=3336 MHz; 2=3358 MHz; 3=3293 MHz; 4=3329 MHz; 5=3478 MHz; 6=3370 MHz; 7=3323 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.065206695993197e-06
+                        ]
+                    ],
+                    "values": [
+                        5.978074431922664e-06,
+                        5.9022385565654645e-06,
+                        5.869953643156123e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658020.4491844177,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17055744,
+                        "load_avg_1min": 0.85,
+                        "duration": 0.824205898999935,
+                        "date": "2020-10-13 10:13:58.445791",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=57 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3361 MHz; 1=3356 MHz; 2=3382 MHz; 3=3350 MHz; 4,7=3363 MHz; 5=3481 MHz; 6=3354 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.222233490227325e-06
+                        ]
+                    ],
+                    "values": [
+                        5.965925170769992e-06,
+                        6.037812958048505e-06,
+                        6.274296356245657e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658021.3536448479,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16859136,
+                        "load_avg_1min": 0.85,
+                        "duration": 0.8466478820191696,
+                        "date": "2020-10-13 10:13:59.350288",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=57 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3347 MHz; 1=3375 MHz; 2=3339 MHz; 3=3370 MHz; 4=3336 MHz; 5=3467 MHz; 6=3351 MHz; 7=3353 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.986582214845271e-06
+                        ]
+                    ],
+                    "values": [
+                        5.942239410750005e-06,
+                        6.0280670775014755e-06,
+                        5.994149718802078e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658022.240883112,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17166336,
+                        "load_avg_1min": 0.85,
+                        "duration": 0.8291044950019568,
+                        "date": "2020-10-13 10:14:00.237383",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=42 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3370 MHz; 1=3418 MHz; 2,7=3352 MHz; 3=3362 MHz; 4=3361 MHz; 5=3478 MHz; 6=3375 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.8734234311685896e-06
+                        ]
+                    ],
+                    "values": [
+                        5.996574707012314e-06,
+                        5.9224508355271155e-06,
+                        6.08554092362823e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658023.1244149208,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16867328,
+                        "load_avg_1min": 0.85,
+                        "duration": 0.8255410979909357,
+                        "date": "2020-10-13 10:14:01.121029",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=42 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3365 MHz; 1=3424 MHz; 2=3367 MHz; 3,7=3378 MHz; 4=3369 MHz; 5=3484 MHz; 6=3384 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.961512329122343e-06
+                        ]
+                    ],
+                    "values": [
+                        5.915230529396354e-06,
+                        5.949177795727678e-06,
+                        5.933404175095802e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658024.0082325935,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17080320,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.822705466998741,
+                        "date": "2020-10-13 10:14:02.004708",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3153 MHz; 1=3271 MHz; 2=3339 MHz; 3=3317 MHz; 4=3318 MHz; 5=3459 MHz; 6=3307 MHz; 7=3327 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.050601074392148e-06
+                        ]
+                    ],
+                    "values": [
+                        6.043715728765164e-06,
+                        5.996287719689519e-06,
+                        5.985893249516039e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658024.8999948502,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16879616,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.8321543819911312,
+                        "date": "2020-10-13 10:14:02.896684",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=43 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3364 MHz; 1=3371 MHz; 2=3356 MHz; 3=3374 MHz; 4=3379 MHz; 5=3482 MHz; 6=3369 MHz; 7=3353 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.095386963167471e-06
+                        ]
+                    ],
+                    "values": [
+                        6.014444366542193e-06,
+                        6.050838164739503e-06,
+                        6.129728820525315e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658025.7967085838,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16887808,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.8392406319908332,
+                        "date": "2020-10-13 10:14:03.793367",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=55 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3371 MHz; 1=3426 MHz; 2=3357 MHz; 3=3377 MHz; 4=3379 MHz; 5=3481 MHz; 6=3375 MHz; 7=3335 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.0620571593617e-06
+                        ]
+                    ],
+                    "values": [
+                        6.314808990381948e-06,
+                        6.020635437309352e-06,
+                        6.09813098151335e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658026.7007231712,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16867328,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.8456943340133876,
+                        "date": "2020-10-13 10:14:04.697358",
+                        "cpu_temp": "coretemp:Package id 0=55 C, coretemp:Core 0=43 C, coretemp:Core 1=55 C, coretemp:Core 2=42 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3349 MHz; 1=3368 MHz; 2=3345 MHz; 3=3363 MHz; 4=3382 MHz; 5=3476 MHz; 6=3358 MHz; 7=3356 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.147008178913893e-06
+                        ]
+                    ],
+                    "values": [
+                        6.031034882170161e-06,
+                        5.871100769105908e-06,
+                        6.1407377014432996e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658027.5942087173,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16879616,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.83558927802369,
+                        "date": "2020-10-13 10:14:05.590833",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3354 MHz; 1=3478 MHz; 2=3347 MHz; 3=3362 MHz; 4=3365 MHz; 5=3469 MHz; 6=3372 MHz; 7=3364 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.00788452143064e-06
+                        ]
+                    ],
+                    "values": [
+                        6.226584228663512e-06,
+                        6.390384918120162e-06,
+                        5.919054778757982e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658028.5021996498,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16822272,
+                        "load_avg_1min": 0.86,
+                        "duration": 0.8479691010143142,
+                        "date": "2020-10-13 10:14:06.498620",
+                        "cpu_temp": "coretemp:Package id 0=56 C, coretemp:Core 0=43 C, coretemp:Core 1=56 C, coretemp:Core 2=42 C, coretemp:Core 3=44 C",
+                        "cpu_freq": "0=3325 MHz; 1=3372 MHz; 2=3348 MHz; 3=3290 MHz; 4=3434 MHz; 5=3207 MHz; 6=3333 MHz; 7=3317 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.104130249262596e-06
+                        ]
+                    ],
+                    "values": [
+                        6.092505096866319e-06,
+                        5.921342498993454e-06,
+                        6.1134198912071724e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658029.4019687176,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17072128,
+                        "load_avg_1min": 0.87,
+                        "duration": 0.8390498359804042,
+                        "date": "2020-10-13 10:14:07.398337",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3470 MHz; 1,6=3345 MHz; 2=3322 MHz; 3=3313 MHz; 4=3436 MHz; 5=3321 MHz; 7=3346 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.061982300131774e-06
+                        ]
+                    ],
+                    "values": [
+                        6.326817169721721e-06,
+                        6.038017700049636e-06,
+                        6.145138061519617e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658030.3089265823,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16826368,
+                        "load_avg_1min": 0.87,
+                        "duration": 0.8488615170062985,
+                        "date": "2020-10-13 10:14:08.305463",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=42 C",
+                        "cpu_freq": "0=3455 MHz; 1=3295 MHz; 2=3186 MHz; 3=3465 MHz; 4=3353 MHz; 5=3349 MHz; 6=3273 MHz; 7=3250 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.025849945245909e-06
+                        ]
+                    ],
+                    "values": [
+                        6.142048736279548e-06,
+                        5.959338562178118e-06,
+                        6.240613647179316e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658031.213704586,
+                        "runnable_threads": 3,
+                        "mem_max_rss": 17084416,
+                        "load_avg_1min": 0.87,
+                        "duration": 0.8460694859968498,
+                        "date": "2020-10-13 10:14:09.210329",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=45 C, coretemp:Core 2=44 C, coretemp:Core 3=45 C",
+                        "cpu_freq": "0=3383 MHz; 1=3322 MHz; 2=3342 MHz; 3=3413 MHz; 4=3470 MHz; 5=3354 MHz; 6=3339 MHz; 7=3358 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.059262909197116e-06
+                        ]
+                    ],
+                    "values": [
+                        6.131081787152937e-06,
+                        6.032978027370461e-06,
+                        6.011509460890352e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658032.111669302,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16875520,
+                        "load_avg_1min": 0.87,
+                        "duration": 0.8374493499868549,
+                        "date": "2020-10-13 10:14:10.108056",
+                        "cpu_temp": "coretemp:Package id 0=54 C, coretemp:Core 0=54 C, coretemp:Core 1=45 C, coretemp:Core 2=44 C, coretemp:Core 3=45 C",
+                        "cpu_freq": "0=3274 MHz; 1=3364 MHz; 2=3332 MHz; 3=3351 MHz; 4=3466 MHz; 5=3297 MHz; 6=3347 MHz; 7=3261 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.09324163836078e-06
+                        ]
+                    ],
+                    "values": [
+                        6.073151214813777e-06,
+                        6.059409332515031e-06,
+                        6.121319092500244e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658033.0110416412,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 17080320,
+                        "load_avg_1min": 0.87,
+                        "duration": 0.8413227889977861,
+                        "date": "2020-10-13 10:14:11.007637",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3482 MHz; 1=3333 MHz; 2=3253 MHz; 3=3294 MHz; 4=3401 MHz; 5=3317 MHz; 6=3278 MHz; 7=3303 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.035354370048651e-06
+                        ]
+                    ],
+                    "values": [
+                        6.015025940442342e-06,
+                        6.019204651153132e-06,
+                        6.028070709263034e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658033.903380394,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16887808,
+                        "load_avg_1min": 0.88,
+                        "duration": 0.8323507160239387,
+                        "date": "2020-10-13 10:14:11.900101",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=43 C, coretemp:Core 2=45 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3485 MHz; 1=3360 MHz; 2=3342 MHz; 3=3333 MHz; 4=3408 MHz; 5=3375 MHz; 6=3366 MHz; 7=3356 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            6.1169834602026185e-06
+                        ]
+                    ],
+                    "values": [
+                        6.1410881349033275e-06,
+                        5.939439239988076e-06,
+                        5.989436676401283e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658034.7988750935,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16826368,
+                        "load_avg_1min": 0.88,
+                        "duration": 0.8370523740013596,
+                        "date": "2020-10-13 10:14:12.795548",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3475 MHz; 1=3361 MHz; 2=3335 MHz; 3=3364 MHz; 4=3391 MHz; 5=3368 MHz; 6=3345 MHz; 7=3371 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.969375915348962e-06
+                        ]
+                    ],
+                    "values": [
+                        6.046466919151783e-06,
+                        5.93448016328324e-06,
+                        6.1195171507932855e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658035.6966423988,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16834560,
+                        "load_avg_1min": 0.88,
+                        "duration": 0.8319766110216733,
+                        "date": "2020-10-13 10:14:13.693232",
+                        "cpu_temp": "coretemp:Package id 0=57 C, coretemp:Core 0=57 C, coretemp:Core 1=42 C, coretemp:Core 2=44 C, coretemp:Core 3=43 C",
+                        "cpu_freq": "0=3458 MHz; 1,4=3235 MHz; 2=3065 MHz; 3=3060 MHz; 5=3055 MHz; 6=3256 MHz; 7=3218 MHz"
+                    }
+                },
+                {
+                    "warmups": [
+                        [
+                            32,
+                            5.96811672970432e-06
+                        ]
+                    ],
+                    "values": [
+                        6.079357269150876e-06,
+                        6.222916992371097e-06,
+                        6.086706634711447e-06
+                    ],
+                    "metadata": {
+                        "uptime": 658036.6010153294,
+                        "runnable_threads": 1,
+                        "mem_max_rss": 16797696,
+                        "load_avg_1min": 0.88,
+                        "duration": 0.8457485850085504,
+                        "date": "2020-10-13 10:14:14.597671",
+                        "cpu_temp": "coretemp:Package id 0=62 C, coretemp:Core 0=44 C, coretemp:Core 1=44 C, coretemp:Core 2=44 C, coretemp:Core 3=62 C",
+                        "cpu_freq": "0=3409 MHz; 1=3353 MHz; 2=3350 MHz; 3=3344 MHz; 4=3351 MHz; 5=3371 MHz; 6=3356 MHz; 7=3478 MHz"
+                    }
+                }
+            ],
+            "metadata": {
+                "timeit_stmt": "'[1,2,3]*1000'",
+                "name": "[1,2,3]*1000",
+                "loops": 32,
+                "tags": ["bar"]
+            }
+        }
+    ]
+}

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -330,6 +330,83 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
         """
         self.check_command(expected, 'compare_to', '--table', "--group-by-speed", py36, py37)
 
+    def test_compare_to_cli_tags(self):
+        py36 = os.path.join(TESTDIR, 'mult_list_py36_tags.json')
+        py37 = os.path.join(TESTDIR, 'mult_list_py37_tags.json')
+
+        # 2 files
+        expected = """
+            Benchmarks with tag 'bar':
+            ==========================
+
+            [1,2]*1000: Mean +- std dev: [mult_list_py36_tags] 3.70 us +- 0.05 us -> [mult_list_py37_tags] 5.28 us +- 0.09 us: 1.42x slower
+            [1,2,3]*1000: Mean +- std dev: [mult_list_py36_tags] 4.61 us +- 0.13 us -> [mult_list_py37_tags] 6.05 us +- 0.11 us: 1.31x slower
+
+            Geometric mean: 1.37x slower
+
+            Benchmarks with tag 'foo':
+            ==========================
+
+            [1]*1000: Mean +- std dev: [mult_list_py36_tags] 2.13 us +- 0.06 us -> [mult_list_py37_tags] 2.09 us +- 0.04 us: 1.02x faster
+            [1,2]*1000: Mean +- std dev: [mult_list_py36_tags] 3.70 us +- 0.05 us -> [mult_list_py37_tags] 5.28 us +- 0.09 us: 1.42x slower
+
+            Geometric mean: 1.18x slower
+
+            All benchmarks:
+            ===============
+
+            [1]*1000: Mean +- std dev: [mult_list_py36_tags] 2.13 us +- 0.06 us -> [mult_list_py37_tags] 2.09 us +- 0.04 us: 1.02x faster
+            [1,2]*1000: Mean +- std dev: [mult_list_py36_tags] 3.70 us +- 0.05 us -> [mult_list_py37_tags] 5.28 us +- 0.09 us: 1.42x slower
+            [1,2,3]*1000: Mean +- std dev: [mult_list_py36_tags] 4.61 us +- 0.13 us -> [mult_list_py37_tags] 6.05 us +- 0.11 us: 1.31x slower
+
+            Geometric mean: 1.22x slower
+        """
+        self.check_command(expected, 'compare_to', py36, py37)
+
+        expected = """
+            Benchmarks with tag 'bar':
+            ==========================
+
+            +----------------+---------------------+-----------------------+
+            | Benchmark      | mult_list_py36_tags | mult_list_py37_tags   |
+            +================+=====================+=======================+
+            | [1,2]*1000     | 3.70 us             | 5.28 us: 1.42x slower |
+            +----------------+---------------------+-----------------------+
+            | [1,2,3]*1000   | 4.61 us             | 6.05 us: 1.31x slower |
+            +----------------+---------------------+-----------------------+
+            | Geometric mean | (ref)               | 1.37x slower          |
+            +----------------+---------------------+-----------------------+
+
+            Benchmarks with tag 'foo':
+            ==========================
+
+            +----------------+---------------------+-----------------------+
+            | Benchmark      | mult_list_py36_tags | mult_list_py37_tags   |
+            +================+=====================+=======================+
+            | [1]*1000       | 2.13 us             | 2.09 us: 1.02x faster |
+            +----------------+---------------------+-----------------------+
+            | [1,2]*1000     | 3.70 us             | 5.28 us: 1.42x slower |
+            +----------------+---------------------+-----------------------+
+            | Geometric mean | (ref)               | 1.18x slower          |
+            +----------------+---------------------+-----------------------+
+
+            All benchmarks:
+            ===============
+
+            +----------------+---------------------+-----------------------+
+            | Benchmark      | mult_list_py36_tags | mult_list_py37_tags   |
+            +================+=====================+=======================+
+            | [1]*1000       | 2.13 us             | 2.09 us: 1.02x faster |
+            +----------------+---------------------+-----------------------+
+            | [1,2]*1000     | 3.70 us             | 5.28 us: 1.42x slower |
+            +----------------+---------------------+-----------------------+
+            | [1,2,3]*1000   | 4.61 us             | 6.05 us: 1.31x slower |
+            +----------------+---------------------+-----------------------+
+            | Geometric mean | (ref)               | 1.22x slower          |
+            +----------------+---------------------+-----------------------+
+        """
+        self.check_command(expected, 'compare_to', '--table', py36, py37)
+
     def test_compare_to_cli_min_speed(self):
         py36 = os.path.join(TESTDIR, 'mult_list_py36.json')
         py37 = os.path.join(TESTDIR, 'mult_list_py37.json')


### PR DESCRIPTION
Addresses https://github.com/python/pyperformance/issues/208

This reports geometric mean organized by the tag(s) assigned to each benchmark.
This will allow us to include benchmarks in the pyperformance suite that we
don't necessarily want to include in "one big overall number" to represent progress.