### PR TITLE
Collect specialization statistics from running benchmarks

### DIFF
--- a/doc/run_benchmark.rst
+++ b/doc/run_benchmark.rst
@@ -191,4 +191,14 @@ mentioned above. Running an arbitrary number of warmup values may also make
 the benchmark less reliable since two runs may use a different number of warmup
 values.
 
+Specializer statistics (`pystats`)
+==================================
 
+If running benchmarks on a CPython built with the ``--enable-pystats`` flag, pyperf will automatically collect statistics from about the bytecode specializer during the run of benchmark code.
+
+Due to the overhead of collecting the statistics, it is unlikely the timing results will be useful.
+
+The `Tools/scripts/summarize_stats.py <https://github.com/python/cpython/blob/main/Tools/scripts/summarize_stats.py>`_ script to summarize the statistics in a human-readable form.
+
+Statistics are not cleared between runs.
+If you need to delete statistics from a previous run, remove the files in `/tmp/py_stats` (Unix) or `C:\temp\py_stats` (Windows).

--- a/pyperf/__init__.py
+++ b/pyperf/__init__.py
@@ -18,3 +18,12 @@ __all__.extend(('Run', 'Benchmark', 'BenchmarkSuite', 'add_runs'))
 
 from pyperf._runner import Runner   # noqa
 __all__.append('Runner')
+
+import sys
+
+# Reset the stats collection if running a --enable-pystats build
+try:
+    sys._stats_off()
+    sys._stats_clear()
+except AttributeError:
+    pass

--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -116,6 +116,10 @@ def collect_python_metadata(metadata):
         if not gc.isenabled():
             metadata['python_gc'] = 'disabled'
 
+    # pystats enabled?
+    if hasattr(sys, "_stats_clear"):
+        metadata['python_pystats'] = 'enabled'
+
 
 def read_proc(path):
     path = proc_path(path)


### PR DESCRIPTION
This will collect statistics on CPython builds with `--enable-pyperf`, and only during the run of the benchmarks themselves.

Cc @markshannon