### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
         python: ['3.11']
         include:
           - os: ubuntu-latest
-            python: '3.6'
-          - os: ubuntu-latest
             python: '3.7'
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.10']
+        python: ['3.11']
         include:
           - os: ubuntu-latest
             python: '3.6'
@@ -22,6 +22,8 @@ jobs:
             python: '3.8'
           - os: ubuntu-latest
             python: '3.9'
+          - os: ubuntu-latest
+            python: '3.10'
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Command to install pyperf on Python 3::
 
     python3 -m pip install pyperf
 
-pyperf requires Python 3.6 or newer.
+pyperf requires Python 3.7 or newer.
 
 Python 2.7 users can use pyperf 1.7.1 which is the last version compatible with
 Python 2.7.

--- a/pyperf/__main__.py
+++ b/pyperf/__main__.py
@@ -580,7 +580,7 @@ def cmd_hist(args):
                                      checks=checks):
             print(line)
 
-        if not(is_last or ignored):
+        if not (is_last or ignored):
             print()
 
     for suite, ignored in ignored:
@@ -691,7 +691,7 @@ def cmd_convert(args):
         for benchmark in suite:
             benchmark._remove_all_metadata()
 
-    compact = not(args.indent)
+    compact = not args.indent
     if args.output_filename:
         suite.dump(args.output_filename, compact=compact)
     else:

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -93,7 +93,7 @@ class Run(object):
 
     def __init__(self, values, warmups=None,
                  metadata=None, collect_metadata=True):
-        if any(not(isinstance(value, NUMBER_TYPES) and value > 0)
+        if any(not (isinstance(value, NUMBER_TYPES) and value > 0)
                for value in values):
             raise ValueError("values must be a sequence of number > 0.0")
 
@@ -425,7 +425,7 @@ class Benchmark(object):
         return value
 
     def percentile(self, p):
-        if not(0 <= p <= 100):
+        if not (0 <= p <= 100):
             raise ValueError("p must be in the range [0; 100]")
         return percentile(self.get_values(), p / 100.0)
 

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -255,7 +255,7 @@ def format_stats(bench, lines):
     else:
         text = "%s (average)" % total_loops
 
-    if not(isinstance(inner_loops, int) and inner_loops == 1):
+    if not (isinstance(inner_loops, int) and inner_loops == 1):
         if isinstance(loops, int):
             loops = format_number(loops, 'outer-loop')
         else:
@@ -324,7 +324,7 @@ def format_stats(bench, lines):
     iqr = q3 - q1
     outlier_min = (q1 - 1.5 * iqr)
     outlier_max = (q3 + 1.5 * iqr)
-    noutlier = sum(not(outlier_min <= value <= outlier_max)
+    noutlier = sum(not (outlier_min <= value <= outlier_max)
                    for value in values)
     bounds = bench.format_values((outlier_min, outlier_max))
     lines.append('Number of outlier (out of %s..%s): %s'

--- a/pyperf/_compare.py
+++ b/pyperf/_compare.py
@@ -395,7 +395,7 @@ class CompareSuites:
             for result in results:
                 lines.extend(result.format(self.verbose))
 
-            if not(significant or self.verbose):
+            if not (significant or self.verbose):
                 not_significant.append(results.name)
                 continue
 
@@ -472,7 +472,7 @@ class CompareSuites:
                 ]
                 self.compare_suites(all_results)
                 print()
-            display_title(f"All benchmarks:")
+            display_title("All benchmarks:")
         self.compare_suites(self.all_results)
 
         if not self.quiet:

--- a/pyperf/_manager.py
+++ b/pyperf/_manager.py
@@ -92,7 +92,7 @@ class Manager(object):
                     # bInheritHandles=True. For pass_handles, see
                     # http://bugs.python.org/issue19764
                     kw['close_fds'] = False
-                elif sys.version_info >= (3, 2):
+                else:
                     kw['pass_fds'] = [wpipe.fd]
 
                 proc = subprocess.Popen(cmd, env=env, **kw)

--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -371,7 +371,7 @@ def median_abs_dev(values):
 
 
 def percentile(values, p):
-    if not isinstance(p, float) or not(0.0 <= p <= 1.0):
+    if not isinstance(p, float) or not (0.0 <= p <= 1.0):
         raise ValueError("p must be a float in the range [0.0; 1.0]")
 
     values = sorted(values)
@@ -427,4 +427,3 @@ def merge_profile_stats(profiler, dst):
         dst_stats.dump_stats(dst)
     else:
         profiler.dump_stats(dst)
-

--- a/pyperf/_worker.py
+++ b/pyperf/_worker.py
@@ -133,7 +133,7 @@ class WorkerTask:
         iqr = q3 - q1
         outlier_max = (q3 + 1.5 * iqr)
         # only check maximum, not minimum
-        outlier = not(first_value <= outlier_max)
+        outlier = not (first_value <= outlier_max)
 
         mean1 = statistics.mean(sample1)
         mean2 = statistics.mean(sample2)
@@ -185,7 +185,7 @@ class WorkerTask:
 
         if outlier:
             return False
-        if not(-0.5 <= mean_diff <= 0.10):
+        if not (-0.5 <= mean_diff <= 0.10):
             return False
         if abs(mad_diff) > 0.10:
             return False

--- a/pyperf/tests/__init__.py
+++ b/pyperf/tests/__init__.py
@@ -15,10 +15,7 @@ from pyperf._utils import popen_communicate, popen_killer
 def _capture_stream(name):
     old_stream = getattr(sys, name)
     try:
-        if sys.version_info >= (3,):
-            stream = io.StringIO()
-        else:
-            stream = io.BytesIO()
+        stream = io.StringIO()
         setattr(sys, name, stream)
         yield stream
     finally:

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -154,7 +154,6 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
         self.assertEqual(stdout.rstrip(),
                          expected)
 
-
     def test_compare_to_md_table(self):
         ref_result = self.create_bench((1.0,),
                                        metadata={'name': 'telco'})

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -74,6 +74,7 @@ class TestRunner(unittest.TestCase):
         self.assertEqual(bench.get_nrun(), 1)
 
         return Result(runner, bench, stdout)
+
     def test_worker(self):
         result = self.exec_runner('--worker', '-l1', '-w1')
         self.assertRegex(result.stdout,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 #
 # Release a new version:
 #
-#  - go to the Github release tab: https://github.com/psf/pyperf/releases
+#  - go to the GitHub release tab: https://github.com/psf/pyperf/releases
 #  - click "Draft a new release" and fill the contents
 #  - finally click the "Publish release" button! Done!
 #  - monitor the publish status: https://github.com/psf/pyperf/actions/workflows/publish.yml
@@ -39,7 +39,7 @@ CLASSIFIERS = [
 
 
 # put most of the code inside main() to be able to import setup.py in
-# test_tools.py, to ensure that VERSION is the same than
+# test_tools.py, to ensure that VERSION is the same as
 # pyperf.__version__.
 def main():
     from setuptools import setup
@@ -61,9 +61,6 @@ def main():
         'install_requires': [],
         # don't use environment markers in install_requires, but use weird
         # syntax of extras_require, to support setuptools 18
-        'extras_require': {
-            ":python_version < '3.4'": ["statistics"],
-        },
         'entry_points': {
             'console_scripts': ['pyperf=pyperf.__main__:main']
         }


### PR DESCRIPTION
Also drop support for EOL Python <= 3.6 and fix errors found running `tox -e pep8`.