### PR TITLE
pyproject.toml: Add Python3.6 as available Python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
         python: ['3.11']
         include:
           - os: ubuntu-latest
+            python: '3.6'
+          - os: ubuntu-latest
             python: '3.7'
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,45 @@
+name: Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pep8:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: ['3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e pep8
+  doc:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: ['3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e doc

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Command to install pyperf on Python 3::
 
     python3 -m pip install pyperf
 
-pyperf requires Python 3.7 or newer.
+pyperf requires Python 3.6 or newer.
 
 Python 2.7 users can use pyperf 1.7.1 which is the last version compatible with
 Python 2.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 dependencies = ["psutil>=5.9.0"]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands=
 basepython = python3
 deps = flake8
 commands =
-    flake8 pyperf setup.py doc/examples/
+    flake8 pyperf doc/examples/
 
 [flake8]
 # E501 line too long (88 > 79 characters)


### PR DESCRIPTION
We dropped the support for Python 3.6 through https://github.com/psf/pyperf/pull/142.
Technically, it was available to be installed at Python 3.6 but since [pyperformance still uses Python 3.6,](https://github.com/python/pyperformance/pull/249#discussion_r1035191258) 
I think that we should sync the version support with the pyperformance team.

There was a restriction at `pyproject.toml` but it was never published to PyPI yet luckily.