### PR TITLE
Fix tracemalloc error when action isn't defined

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.6.1
+-------------
+
+* Fix a possible attribute error in argument parsing.
+  Patch by Colton Myers
+
 Version 2.6.0 (2023-03-22)
 --------------------------
 

--- a/pyperf/_runner.py
+++ b/pyperf/_runner.py
@@ -331,7 +331,7 @@ class Runner:
             self._only_in_worker("--worker-task")
 
         if args.tracemalloc:
-            if args.action == 'command':
+            if hasattr(args, "action") and args.action == 'command':
                 raise CLIError('--tracemalloc cannot be used with pyperf command')
             try:
                 import tracemalloc   # noqa

--- a/pyperf/_runner.py
+++ b/pyperf/_runner.py
@@ -331,7 +331,7 @@ class Runner:
             self._only_in_worker("--worker-task")
 
         if args.tracemalloc:
-            if hasattr(args, "action") and args.action == 'command':
+            if getattr(args, 'action', None) == 'command':
                 raise CLIError('--tracemalloc cannot be used with pyperf command')
             try:
                 import tracemalloc   # noqa


### PR DESCRIPTION
Ref #131 

[We're using the `Runner`'s argument parsing](https://github.com/elastic/apm-agent-python-benchmarks/blob/1cacb6fef93ec570c15472c3df757eef1bfd2d28/run_bench.py#L36), but without using `pyperf` directly. This is resulting in an undefined `action`, which means that when we use the `--tracemalloc` argument, we get the following error:

```
  File ".../python3.8/site-packages/pyperf/_runner.py", line 334, in _process_args_impl

    if args.action == 'command':

AttributeError: 'Namespace' object has no attribute 'action'
```

This PR checks for the attribute before accessing it.