### PR TITLE
Add 3.12 and remove 3.7 from the build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.11']
+        python: ['3.12']
         include:
           - os: ubuntu-latest
             python: 'pypy3.9'
@@ -21,13 +21,13 @@ jobs:
           - os: ubuntu-latest
             python: 'pypy3.7'
           - os: ubuntu-latest
-            python: '3.7'
-          - os: ubuntu-latest
             python: '3.8'
           - os: ubuntu-latest
             python: '3.9'
           - os: ubuntu-latest
             python: '3.10'
+          - os: ubuntu-latest
+            python: '3.11'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
         python: ['3.12']
         include:
           - os: ubuntu-latest
+            python: 'pypy3.10'
+          - os: ubuntu-latest
             python: 'pypy3.9'
           - os: ubuntu-latest
             python: 'pypy3.8'
-          - os: ubuntu-latest
-            python: 'pypy3.7'
           - os: ubuntu-latest
             python: '3.8'
           - os: ubuntu-latest


### PR DESCRIPTION
3.7 is EOL now: https://devguide.python.org/versions/