### PR TITLE
Include pystats during warmups

### DIFF
--- a/pyperf/_worker.py
+++ b/pyperf/_worker.py
@@ -59,8 +59,8 @@ class WorkerTask:
         task_func = self.task_func
 
         # If we are on a pystats build, turn on stats collection around the
-        # actual work, but only if we aren't warming up or calibrating.
-        if hasattr(sys, "_stats_on") and not is_warmup and not calibrate_loops:
+        # actual work, except when calibrating.
+        if hasattr(sys, "_stats_on") and not calibrate_loops:
             core_task_func = task_func
 
             def stats_func(*args):


### PR DESCRIPTION
On [recent investigations](https://github.com/faster-cpython/bench_runner/issues/52), it's become clear that the support for py_stats in pyperf (that I myself originally submitted) isn't ideal, since stats aren't collected during warmups.  Since warmups run in the same process as the "main" runs, if any optimizations or specializations are performed during the warmup, they aren't recorded in the stats.

This change simply includes warmups in stats collection.  Calibration runs are left as is, since they are run in a separate process.