### PR TITLE
Include `CONFIG_ARGS` in Metadata

### DIFF
--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -106,11 +106,11 @@ def collect_python_metadata(metadata):
         if cflags:
             cflags = normalize_text(cflags)
             metadata['python_cflags'] = cflags
-            
-        config_flags = sysconfig.get_config_var('CONFIG_ARGS')
-        if config_flags:
-            config_flags = normalize_text(config_flags)
-            metadata['python_config_args'] = config_flags
+
+        config_args = sysconfig.get_config_var('CONFIG_ARGS')
+        if config_args:
+            config_args = normalize_text(config_args)
+            metadata['python_config_args'] = config_args
 
     # GC disabled?
     try:

--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -106,6 +106,11 @@ def collect_python_metadata(metadata):
         if cflags:
             cflags = normalize_text(cflags)
             metadata['python_cflags'] = cflags
+            
+        config_flags = sysconfig.get_config_var('CONFIG_ARGS')
+        if config_flags:
+            config_flags = normalize_text(config_flags)
+            metadata['python_config_args'] = config_flags
 
     # GC disabled?
     try:


### PR DESCRIPTION
This PR includes the value of `sys.get_config_var('CONFIG_ARGS')` in the metadata for a benchmark run.

This value is _not_ added to `_bench._CHECKED_METADATA`, since it is often useful and desired to compare two benchmarks with different build configs.

Closes #179 