### PR TITLE
Minor optimizations by using comprehensions

### DIFF
--- a/pyperf/__main__.py
+++ b/pyperf/__main__.py
@@ -349,11 +349,7 @@ class Benchmarks:
     def group_by_name_ignored(self):
         names = set(self._group_by_name_names())
         for suite in self.suites:
-            ignored = []
-            for bench in suite:
-                if bench.get_name() not in names:
-                    ignored.append(bench)
-            if ignored:
+            if ignored := [bench for bench in suite if bench.get_name() not in names]:
                 yield (suite, ignored)
 
 

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -557,10 +557,7 @@ class Benchmark(object):
         if include:
             old_runs = self._runs
             max_index = len(old_runs) - 1
-            runs = []
-            for index in only_runs:
-                if index <= max_index:
-                    runs.append(old_runs[index])
+            runs = [old_runs[index] for index in only_runs if index <= max_index]
         else:
             runs = self._runs
             max_index = len(runs) - 1

--- a/pyperf/_compare.py
+++ b/pyperf/_compare.py
@@ -163,10 +163,7 @@ class ReSTTable:
                 self.widths[column] = max(self.widths[column], len(cell))
 
     def _render_line(self, char='-'):
-        parts = ['']
-        for width in self.widths:
-            parts.append(char * (width + 2))
-        parts.append('')
+        parts = [''] + [char * (width + 2) for width in self.widths] + ['']
         return '+'.join(parts)
 
     def _render_row(self, row):
@@ -250,7 +247,7 @@ class CompareSuites:
         for results in self.all_results:
             for result in results:
                 self.tags.update(get_tags_for_result(result))
-        self.tags = sorted(list(self.tags))
+        self.tags = sorted(self.tags)
 
     def compare_benchmarks(self, name, benchmarks):
         min_speed = self.min_speed
@@ -280,9 +277,9 @@ class CompareSuites:
 
             self.all_results.sort(key=sort_key)
 
-        headers = ['Benchmark', self.all_results[0][0].ref.name]
-        for item in self.all_results[0]:
-            headers.append(item.changed.name)
+        headers = ['Benchmark', self.all_results[0][0].ref.name] + [
+            item.changed.name for item in self.all_results[0]
+        ]
 
         all_norm_means = [[] for _ in range(len(headers[2:]))]
 
@@ -427,9 +424,7 @@ class CompareSuites:
     def compare_geometric_mean(self, all_results):
         # use a list since two filenames can be identical,
         # even if results are different
-        all_norm_means = []
-        for item in all_results[0]:
-            all_norm_means.append((item.changed.name, []))
+        all_norm_means = [(item.changed.name, []) for item in all_results[0]]
 
         for results in all_results:
             for index, result in enumerate(results):

--- a/pyperf/_cpu_utils.py
+++ b/pyperf/_cpu_utils.py
@@ -90,8 +90,7 @@ def parse_cpu_list(cpu_list):
             parts = part.split('-', 1)
             first = int(parts[0])
             last = int(parts[1])
-            for cpu in range(first, last + 1):
-                cpus.append(cpu)
+            cpus.extend(range(first, last + 1))
         else:
             cpus.append(int(part))
     cpus.sort()

--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -129,8 +129,7 @@ def parse_run_list(run_list):
                 parts = part.split('-', 1)
                 first = int(parts[0])
                 last = int(parts[1])
-                for run in range(first, last + 1):
-                    runs.append(run)
+                runs.extend(range(first, last + 1))
             else:
                 runs.append(int(part))
         except ValueError:

--- a/pyperf/tests/test_bench.py
+++ b/pyperf/tests/test_bench.py
@@ -346,11 +346,9 @@ class BenchmarkTests(unittest.TestCase):
                          {'name': 'bench', 'unit': 'byte'})
 
     def test_update_metadata(self):
-        runs = []
-        for value in (1.0, 2.0, 3.0):
-            runs.append(pyperf.Run((value,),
-                                   metadata={'name': 'bench'},
-                                   collect_metadata=False))
+        runs = [pyperf.Run((value,),
+                           metadata={'name': 'bench'},
+                           collect_metadata=False) for value in (1.0, 2.0, 3.0)]
         bench = pyperf.Benchmark(runs)
         self.assertEqual(bench.get_metadata(),
                          {'name': 'bench'})


### PR DESCRIPTION
% `ruff check --select=C4,PERF --ignore=PERF203`
```
pyperf/__main__.py:355:21: PERF401 Use a list comprehension to create a transformed list
pyperf/_bench.py:563:21: PERF401 Use a list comprehension to create a transformed list
pyperf/_compare.py:168:13: PERF401 Use a list comprehension to create a transformed list
pyperf/_compare.py:253:21: C414 Unnecessary `list` call within `sorted()`
pyperf/_compare.py:285:13: PERF401 Use a list comprehension to create a transformed list
pyperf/_compare.py:432:13: PERF401 Use a list comprehension to create a transformed list
pyperf/_cpu_utils.py:94:17: PERF402 Use `list` or `list.copy` to create a copy of a list
pyperf/_utils.py:133:21: PERF402 Use `list` or `list.copy` to create a copy of a list
pyperf/tests/test_bench.py:351:13: PERF401 Use a list comprehension to create a transformed list
Found 9 errors.
```
% `ruff rule PERF401`
# manual-list-comprehension (PERF401)

Derived from the **Perflint** linter.

## What it does
Checks for `for` loops that can be replaced by a list comprehension.

## Why is this bad?
When creating a transformed list from an existing list using a for-loop,
prefer a list comprehension. List comprehensions are more readable and
more performant.

Using the below as an example, the list comprehension is ~10% faster on
Python 3.11, and ~25% faster on Python 3.10.

Note that, as with all `perflint` rules, this is only intended as a
micro-optimization, and will have a negligible impact on performance in
most cases.

## Example
```python
original = list(range(10000))
filtered = []
for i in original:
    if i % 2:
        filtered.append(i)
```

Use instead:
```python
original = list(range(10000))
filtered = [x for x in original if x % 2]
```

If you're appending to an existing list, use the `extend` method instead:
```python
original = list(range(10000))
filtered.extend(x for x in original if x % 2)
```
