### PR TITLE
Add some ruff rules for pyupgrade

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # pyperf documentation build configuration file, created by
 # sphinx-quickstart on Wed Jun  1 15:28:03 2016.
@@ -42,9 +41,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'pyperf'
-copyright = u'2016, Victor Stinner'
-author = u'Victor Stinner'
+project = 'pyperf'
+copyright = '2016, Victor Stinner'
+author = 'Victor Stinner'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -216,8 +215,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'pyperf.tex', u'pyperf Documentation',
-   u'Victor Stinner', 'manual'),
+  (master_doc, 'pyperf.tex', 'pyperf Documentation',
+   'Victor Stinner', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -246,7 +245,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'pyperf', u'pyperf Documentation',
+    (master_doc, 'pyperf', 'pyperf Documentation',
      [author], 1)
 ]
 
@@ -260,7 +259,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'pyperf', u'pyperf Documentation',
+  (master_doc, 'pyperf', 'pyperf Documentation',
    author, 'pyperf', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -86,7 +86,7 @@ def _cached_attr(func):
     return method
 
 
-class Run(object):
+class Run:
     # Run is immutable, so it can be shared/exchanged between two benchmarks
 
     __slots__ = ('_warmups', '_values', '_metadata')
@@ -319,7 +319,7 @@ class Run(object):
         return self._replace(metadata=metadata2)
 
 
-class Benchmark(object):
+class Benchmark:
     def __init__(self, runs):
         self._runs = []   # list of Run objects
         self._clear_runs_cache()
@@ -627,7 +627,7 @@ class Benchmark(object):
         self._replace_runs(new_runs)
 
 
-class BenchmarkSuite(object):
+class BenchmarkSuite:
     def __init__(self, benchmarks, filename=None):
         if not benchmarks:
             raise ValueError("benchmarks must be a non-empty "
@@ -727,7 +727,7 @@ class BenchmarkSuite(object):
         if isinstance(filename, bytes):
             suffix = b'.gz'
         else:
-            suffix = u'.gz'
+            suffix = '.gz'
 
         if filename.endswith(suffix):
             # Use lazy import to limit imports on 'import pyperf'
@@ -770,7 +770,7 @@ class BenchmarkSuite(object):
         if isinstance(filename, bytes):
             suffix = b'.gz'
         else:
-            suffix = u'.gz'
+            suffix = '.gz'
 
         if not replace and os.path.exists(filename):
             raise OSError(errno.EEXIST, "File already exists")

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -604,7 +604,7 @@ def catch_broken_pipe_error(file=None):
         # was closed by the consumer
         for file in files:
             file.flush()
-    except IOError as exc:
+    except OSError as exc:
         if exc.errno != errno.EPIPE:
             raise
         # got a broken pipe error: ignore it
@@ -615,5 +615,5 @@ def catch_broken_pipe_error(file=None):
         for file in files:
             try:
                 file.close()
-            except IOError:
+            except OSError:
                 pass

--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -136,7 +136,7 @@ def read_proc(path):
         with open_text(path) as fp:
             for line in fp:
                 yield line.rstrip()
-    except (OSError, IOError):
+    except OSError:
         return
 
 
@@ -332,7 +332,7 @@ def get_cpu_temperature(path, cpu_temp):
 
         try:
             temp_label = read_first_line(template % 'label', error=True)
-        except IOError:
+        except OSError:
             break
 
         temp_input = read_first_line(template % 'input', error=True)

--- a/pyperf/_compare.py
+++ b/pyperf/_compare.py
@@ -53,7 +53,7 @@ def get_tags_for_result(result):
     return result.ref.benchmark.get_metadata().get("tags", [])
 
 
-class CompareResult(object):
+class CompareResult:
     def __init__(self, ref, changed, min_speed=None):
         # CompareData object
         self.ref = ref

--- a/pyperf/_linux_memory.py
+++ b/pyperf/_linux_memory.py
@@ -54,7 +54,7 @@ def check_tracking_memory():
     mem_thread = PeakMemoryUsageThread()
     try:
         mem_thread.get()
-    except IOError as exc:
+    except OSError as exc:
         path = proc_path("self/smaps")
         return "unable to read %s: %s" % (path, exc)
 

--- a/pyperf/_manager.py
+++ b/pyperf/_manager.py
@@ -12,7 +12,7 @@ from pyperf._utils import MS_WINDOWS, create_environ, create_pipe, popen_killer
 MAX_CALIBRATION = 5
 
 
-class Manager(object):
+class Manager:
     """
     Manager process which spawns worker processes to:
     - calibrate warmups

--- a/pyperf/_metadata.py
+++ b/pyperf/_metadata.py
@@ -137,7 +137,7 @@ def format_metadata(name, value):
     return info.formatter(value)
 
 
-class Metadata(object):
+class Metadata:
     def __init__(self, name, value):
         self._name = name
         self._value = value

--- a/pyperf/_system.py
+++ b/pyperf/_system.py
@@ -74,7 +74,7 @@ def use_intel_pstate():
     return (scaling_driver == 'intel_pstate')
 
 
-class Operation(object):
+class Operation:
     @staticmethod
     def available():
         return True
@@ -107,7 +107,7 @@ class Operation(object):
     def read_first_line(self, path):
         try:
             return read_first_line(path, error=True)
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             return ''
 
@@ -219,7 +219,7 @@ class TurboBoostMSR(Operation):
                     os.write(fd, data)
             finally:
                 os.close(fd)
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             self.error("Failed to write %#x into MSR %#x using %s: %s"
                        % (value, reg_num, path, exc))
@@ -308,7 +308,7 @@ class TurboBoostIntelPstate(Operation):
         content = '0' if enable else '1'
         try:
             write_text(self.path, content)
-        except IOError as exc:
+        except OSError as exc:
             # don't log a permission error if the user is root: permission
             # error as root means that Turbo Boost is disabled in the BIOS
             if not is_root():
@@ -376,7 +376,7 @@ class CPUGovernorIntelPstate(Operation):
             return
         try:
             write_text(self.path, new_governor)
-        except IOError as exc:
+        except OSError as exc:
             self.error("Failed to set the CPU scaling governor: %s" % exc)
         else:
             self.log_action("CPU scaling governor set to %s" % new_governor)
@@ -495,7 +495,7 @@ class ASLR(Operation):
 
         try:
             write_text(self.path, new_value)
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             self.error("Failed to write into %s: %s" % (self.path, exc))
         else:
@@ -552,7 +552,7 @@ class CPUFrequency(Operation):
         try:
             with open(filename, "rb") as fp:
                 return fp.readline()
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             return None
 
@@ -579,7 +579,7 @@ class CPUFrequency(Operation):
         filename = os.path.join(cpu_path, "scaling_min_freq")
         try:
             return self.write_freq(filename, freq)
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             self.error("Unable to write scaling_max_freq of CPU %s: %s"
                        % (cpu, exc))
@@ -768,7 +768,7 @@ class IRQAffinity(Operation):
         mask = format_cpus_as_mask(new_affinity)
         try:
             write_text(self.default_affinity_path, mask)
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             self.error("Failed to write %r into %s: %s"
                        % (mask, self.default_affinity_path, exc))
@@ -782,7 +782,7 @@ class IRQAffinity(Operation):
         try:
             write_text(path, mask)
             return True
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             # EIO means that the IRQ doesn't support SMP affinity:
             # ignore the error
@@ -937,7 +937,7 @@ class PerfEvent(Operation):
 
         try:
             write_text(self.path, str(new_rate))
-        except IOError as exc:
+        except OSError as exc:
             self.check_permission_error(exc)
             self.error("Failed to write into %s: %s" % (self.path, exc))
         else:

--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -155,7 +155,7 @@ def read_first_line(path, error=False):
         with open_text(path) as fp:
             line = fp.readline()
         return line.rstrip()
-    except IOError:
+    except OSError:
         if error:
             raise
         else:
@@ -282,7 +282,7 @@ def create_environ(inherit_environ, locale, copy_all):
     return env
 
 
-class _Pipe(object):
+class _Pipe:
     _OPEN_MODE = "r"
 
     def __init__(self, fd):

--- a/pyperf/tests/__init__.py
+++ b/pyperf/tests/__init__.py
@@ -55,7 +55,7 @@ def temporary_directory():
 def benchmark_as_json(benchmark, compact=True):
     with temporary_file() as tmp_name:
         benchmark.dump(tmp_name, compact=compact)
-        with io.open(tmp_name, 'r', encoding='utf-8') as tmp:
+        with open(tmp_name, 'r', encoding='utf-8') as tmp:
             return tmp.read()
 
 

--- a/pyperf/tests/replay.py
+++ b/pyperf/tests/replay.py
@@ -14,7 +14,7 @@ def get_raw_values(filename, run_id):
     return (run, raw_values)
 
 
-class Replay(object):
+class Replay:
     def __init__(self, runner, filename):
         self.runner = runner
         self.args = runner.args

--- a/pyperf/tests/test_metadata.py
+++ b/pyperf/tests/test_metadata.py
@@ -159,7 +159,7 @@ class CpuFunctionsTests(unittest.TestCase):
             elif filename.startswith('/sys/devices/system/cpu/nohz_full'):
                 data = nohz_full
             elif filename.startswith('/sys/devices/system/cpu/cpu2'):
-                raise IOError
+                raise OSError
             elif filename == '/sys/devices/system/cpu/cpuidle/current_driver':
                 data = 'IDLE_DRV\n'
             else:
@@ -194,7 +194,7 @@ class CpuFunctionsTests(unittest.TestCase):
             elif filename == '/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor':
                 data = 'GOVERNOR\n'
             elif filename.startswith('/sys/devices/system/cpu/cpu2'):
-                raise IOError
+                raise OSError
             else:
                 raise ValueError("unexpect open: %r" % filename)
             return io.StringIO(data)

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -11,7 +11,7 @@ TESTDIR = os.path.dirname(__file__)
 TELCO = os.path.join(TESTDIR, 'telco.json')
 
 
-class BaseTestCase(object):
+class BaseTestCase:
     maxDiff = 100 * 80
 
     def create_bench(self, values, metadata=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,10 @@ packages = ["pyperf", "pyperf.tests"]
 
 [tool.setuptools.dynamic]
 version = {attr = "pyperf.__version__"}
+
+[tool.ruff.lint]
+extend-select = ["C90", "UP"]
+extend-ignore = ["UP015", "UP031"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 31


### PR DESCRIPTION
% `ruff check --select=SIM,UP --ignore=SIM105,SIM115,SIM117,UP015,UP031 --statistics | sort -k2`
```
23	SIM108	[*] Use ternary operator `char = '=' if level == 1 else '-'` instead of `if`-`else`-block
 1	SIM113	[ ] Use `enumerate()` for index variable `index` in `for` loop
 7	SIM114	[*] Combine `if` branches using logical `or` operator
10	UP004 	[*] Class `BaseTestCase` inherits from `object`
 1	UP009 	[*] UTF-8 encoding declaration is unnecessary
 1	UP020 	[*] Use builtin `open`
18	UP024 	[*] Replace aliased errors with `OSError`
 9	UP025 	[*] Remove unicode literals from strings
```
% `ruff rule UP024`
# os-error-alias (UP024)

Derived from the **pyupgrade** linter.

Fix is always available.

## What it does
Checks for uses of exceptions that alias `OSError`.

## Why is this bad?
`OSError` is the builtin error type used for exceptions that relate to the
operating system.

In Python 3.3, a variety of other exceptions, like `WindowsError` were
aliased to `OSError`. These aliases remain in place for compatibility with
older versions of Python, but may be removed in future versions.

Prefer using `OSError` directly, as it is more idiomatic and future-proof.

## Example
```python
raise IOError
```

Use instead:
```python
raise OSError
```

## References
- [Python documentation: `OSError`](https://docs.python.org/3/library/exceptions.html#OSError)
