### PR TITLE
tox.ini: Replace flake8 with ruff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,19 @@ on:
     branches: [main]
 
 jobs:
+  tox-jobs:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-job: [doc, pep8]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install tox
+      - run: tox -e ${{ matrix.tox-job }}
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -13,18 +13,12 @@ basepython = python3
 [testenv:doc]
 basepython = python3
 deps = sphinx
-whitelist_externals = make
+allowlist_externals = make
 commands=
     make -C doc html
 
 [testenv:pep8]
 basepython = python3
-deps = flake8
+deps = ruff
 commands =
-    flake8 pyperf setup.py doc/examples/
-
-[flake8]
-# E501 line too long (88 > 79 characters)
-# F812 list comprehension redefines 'loops' from line 56
-# W503 line break before binary operator
-ignore = E501,F812,W503
+    ruff check


### PR DESCRIPTION
https://docs.astral.sh/ruff

As recommended at https://github.com/psf/pyperf/pull/183#issuecomment-2081878177

Should we rename the tox job from `pep8` to `lint` or not?
