### PR TITLE
Disable TurboBoost tuning settings on non-Intel

### DIFF
--- a/pyperf/_system.py
+++ b/pyperf/_system.py
@@ -1,5 +1,6 @@
 import errno
 import os.path
+import platform
 import re
 import struct
 import subprocess
@@ -125,7 +126,11 @@ class TurboBoostMSR(Operation):
 
     @staticmethod
     def available():
-        return (OS_LINUX and not use_intel_pstate())
+        return (
+            OS_LINUX and 
+            not use_intel_pstate() and 
+            platform.machine() not in ('x86', 'x86_64', 'amd64')
+        )
 
     def __init__(self, system):
         Operation.__init__(self, 'Turbo Boost (MSR)', system)


### PR DESCRIPTION
I'm in the process of getting pyperf to run on aarch64-linux, and system tune fails with:

```
Errors
======
Turbo Boost (MSR): Failed to read MSR 0x1a0 from /dev/cpu/0/msr: 
[Errno 2] No such file or directory: '/dev/cpu/0/msr'
Turbo Boost (MSR): Try to load the msr kernel module: sudo modprobe msr  
```

As far as I understand, this feature just isn't available on non-Intel.  (There might be an equivalent to adjust the frequencies on ARM, but that can be in a follow-up PR).