### PR TITLE
Fix logic in MSR availability test

### DIFF
--- a/pyperf/_system.py
+++ b/pyperf/_system.py
@@ -129,7 +129,7 @@ class TurboBoostMSR(Operation):
         return (
             OS_LINUX and 
             not use_intel_pstate() and 
-            platform.machine() not in ('x86', 'x86_64', 'amd64')
+            platform.machine() in ('x86', 'x86_64', 'amd64')
         )
 
     def __init__(self, system):


### PR DESCRIPTION
As @vstinner [pointed out](https://github.com/psf/pyperf/pull/185#issuecomment-2092945317) the logic to turn off MSR setting on non-Intel hardware was reversed.