### PR TITLE
Refactor operations to fully work on AArch64.

### DIFF
--- a/pyperf/_system.py
+++ b/pyperf/_system.py
@@ -128,7 +128,7 @@ class IntelPstateOperation(Operation):
 
 class TurboBoostMSR(Operation):
     """
-    Get/Set Turbo Boost mode of X86 CPUs using /dev/cpu/N/msr
+    Get/Set Turbo Boost mode of x86 CPUs using /dev/cpu/N/msr
     """
 
     @staticmethod


### PR DESCRIPTION
Create IntelPstateOperation class for Intel P-State operations.
Enable CPUGovernor on AArch64 platforms.
Replace all Class names with super() in the __init__ method.