### PR TITLE
Fix the max_mem_rss measurement

### DIFF
--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -208,7 +208,7 @@ def collect_system_metadata(metadata):
 
 def collect_memory_metadata(metadata):
     if resource is not None:
-        metadata["mem_max_rss"] = get_max_rss(resource.RUSAGE_SELF)
+        metadata["mem_max_rss"] = get_max_rss(children=False)
 
     # Note: Don't collect VmPeak of /proc/self/status on Linux because it is
     # not accurate. See pyperf._linux_memory for more accurate memory metrics.

--- a/pyperf/_collect_metadata.py
+++ b/pyperf/_collect_metadata.py
@@ -208,7 +208,7 @@ def collect_system_metadata(metadata):
 
 def collect_memory_metadata(metadata):
     if resource is not None:
-        metadata["mem_max_rss"] = get_max_rss()
+        metadata["mem_max_rss"] = get_max_rss(resource.RUSAGE_SELF)
 
     # Note: Don't collect VmPeak of /proc/self/status on Linux because it is
     # not accurate. See pyperf._linux_memory for more accurate memory metrics.

--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -52,6 +52,11 @@ def merge_profile_stats_files(src, dst):
 
 
 def bench_process(loops, args, kw, profile_filename=None):
+    if resource is not None:
+        rusage_children = resource.RUSAGE_CHILDREN
+    else:
+        rusage_children = 0
+
     max_rss = 0
     range_it = range(loops)
     start_time = time.perf_counter()
@@ -61,7 +66,7 @@ def bench_process(loops, args, kw, profile_filename=None):
         args = [args[0], "-m", "cProfile", "-o", temp_profile_filename] + args[1:]
 
     for _ in range_it:
-        start_rss = get_max_rss(resource.RUSAGE_CHILDREN)
+        start_rss = get_max_rss(rusage_children)
 
         proc = subprocess.Popen(args, **kw)
         with proc:
@@ -75,7 +80,7 @@ def bench_process(loops, args, kw, profile_filename=None):
                 os.unlink(temp_profile_filename)
             sys.exit(exitcode)
 
-        rss = get_max_rss(resource.RUSAGE_CHILDREN) - start_rss
+        rss = get_max_rss(rusage_children) - start_rss
         max_rss = max(max_rss, rss)
 
         if profile_filename:

--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -26,7 +26,7 @@ except ImportError:
     resource = None
 
 
-def get_max_rss(children=False):
+def get_max_rss(*, children):
     if resource is not None:
         if children:
             resource_type = resource.RUSAGE_CHILDREN

--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -26,9 +26,9 @@ except ImportError:
     resource = None
 
 
-def get_max_rss():
+def get_max_rss(resource_type=resource.RUSAGE_CHILDREN):
     if resource is not None:
-        usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        usage = resource.getrusage(resource_type)
         if sys.platform == 'darwin':
             return usage.ru_maxrss
         return usage.ru_maxrss * 1024

--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -26,8 +26,10 @@ except ImportError:
     resource = None
 
 
-def get_max_rss(resource_type=resource.RUSAGE_CHILDREN):
+def get_max_rss(resource_type=None):
     if resource is not None:
+        if resource_type is None:
+            resource_type = resource.RUSAGE_CHILDREN
         usage = resource.getrusage(resource_type)
         if sys.platform == 'darwin':
             return usage.ru_maxrss

--- a/pyperf/_process_time.py
+++ b/pyperf/_process_time.py
@@ -26,10 +26,8 @@ except ImportError:
     resource = None
 
 
-def get_max_rss(resource_type=None):
+def get_max_rss(resource_type):
     if resource is not None:
-        if resource_type is None:
-            resource_type = resource.RUSAGE_CHILDREN
         usage = resource.getrusage(resource_type)
         if sys.platform == 'darwin':
             return usage.ru_maxrss
@@ -63,7 +61,7 @@ def bench_process(loops, args, kw, profile_filename=None):
         args = [args[0], "-m", "cProfile", "-o", temp_profile_filename] + args[1:]
 
     for _ in range_it:
-        start_rss = get_max_rss()
+        start_rss = get_max_rss(resource.RUSAGE_CHILDREN)
 
         proc = subprocess.Popen(args, **kw)
         with proc:
@@ -77,7 +75,7 @@ def bench_process(loops, args, kw, profile_filename=None):
                 os.unlink(temp_profile_filename)
             sys.exit(exitcode)
 
-        rss = get_max_rss() - start_rss
+        rss = get_max_rss(resource.RUSAGE_CHILDREN) - start_rss
         max_rss = max(max_rss, rss)
 
         if profile_filename:


### PR DESCRIPTION
In https://github.com/psf/pyperf/commit/c9604435bc46273f3b6e51101ea4091d57a2020b, which fixed a bug in scaling the `mem_max_rss` value on Darwin, I inadvertently changed the measurement from using `RUSAGE_SELF` to `RUSAGE_CHILDREN`.  This has resulted in the measurements being much coarser and incorrect on Darwin.  This reverts to the old correct behavior.