### PR TITLE
Use KiB and MiB as units instead of kB and MB.

### DIFF
--- a/pyperf/_formatter.py
+++ b/pyperf/_formatter.py
@@ -30,9 +30,9 @@ def format_filesize(size):
             return '%.0f byte' % size
 
     if size > 10 * 1024 * 1024:
-        return '%.1f MB' % (size / (1024.0 * 1024.0))
+        return '%.1f MiB' % (size / (1024.0 * 1024.0))
 
-    return '%.1f kB' % (size / 1024.0)
+    return '%.1f kiB' % (size / 1024.0)
 
 
 def format_filesizes(sizes):

--- a/pyperf/_formatter.py
+++ b/pyperf/_formatter.py
@@ -32,7 +32,7 @@ def format_filesize(size):
     if size > 10 * 1024 * 1024:
         return '%.1f MiB' % (size / (1024.0 * 1024.0))
 
-    return '%.1f kiB' % (size / 1024.0)
+    return '%.1f KiB' % (size / 1024.0)
 
 
 def format_filesizes(sizes):

--- a/pyperf/tests/test_metadata.py
+++ b/pyperf/tests/test_metadata.py
@@ -55,7 +55,7 @@ class CpuFunctionsTests(unittest.TestCase):
         stepping\t: 9
         microcode\t: 0x1c
         cpu MHz\t\t: 1287.554
-        cache size\t: 4096 KB
+        cache size\t: 4096 KiB
         physical id\t: 0
         siblings\t: 4
         core id\t\t: 0
@@ -82,7 +82,7 @@ class CpuFunctionsTests(unittest.TestCase):
         stepping\t: 9
         microcode\t: 0x1c
         cpu MHz\t\t: 1225.363
-        cache size\t: 4096 KB
+        cache size\t: 4096 KiB
         physical id\t: 0
         siblings\t: 4
         core id\t\t: 0
@@ -109,7 +109,7 @@ class CpuFunctionsTests(unittest.TestCase):
         stepping\t: 9
         microcode\t: 0x1c
         cpu MHz\t\t: 1200.101
-        cache size\t: 4096 KB
+        cache size\t: 4096 KiB
         physical id\t: 0
         siblings\t: 4
         core id\t\t: 1

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -556,13 +556,13 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
     def test_dump_track_memory(self):
         expected = """
             Run 1: calibrate the number of loops: 2^15
-            - calibrate 1: 7188.0 kiB (loops: 2^15)
+            - calibrate 1: 7188.0 KiB (loops: 2^15)
             Run 2: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7188.0 kiB
+            - value 1: 7188.0 KiB
             Run 3: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7192.0 kiB
+            - value 1: 7192.0 KiB
             Run 4: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7208.0 kiB
+            - value 1: 7208.0 KiB
         """
         filename = os.path.join(TESTDIR, 'track_memory.json')
         stdout = self.run_command('dump', filename)

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -556,13 +556,13 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
     def test_dump_track_memory(self):
         expected = """
             Run 1: calibrate the number of loops: 2^15
-            - calibrate 1: 7188.0 kB (loops: 2^15)
+            - calibrate 1: 7188.0 kiB (loops: 2^15)
             Run 2: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7188.0 kB
+            - value 1: 7188.0 kiB
             Run 3: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7192.0 kB
+            - value 1: 7192.0 kiB
             Run 4: 0 warmups, 1 value, 2^15 loops
-            - value 1: 7208.0 kB
+            - value 1: 7208.0 kiB
         """
         filename = os.path.join(TESTDIR, 'track_memory.json')
         stdout = self.run_command('dump', filename)
@@ -595,7 +595,7 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
               date: 2016-10-21 03:14:19.670631
               duration: 338 ms
               load_avg_1min: 0.29
-              mem_max_rss: 13.4 MB
+              mem_max_rss: 13.4 MiB
               runnable_threads: 1
               uptime: 2 day 2 hour 4 min
             Run 2: 1 warmup, 3 values, 8 loops
@@ -609,7 +609,7 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
               date: 2016-10-21 03:14:20.496710
               duration: 723 ms
               load_avg_1min: 0.29
-              mem_max_rss: 13.5 MB
+              mem_max_rss: 13.5 MiB
               runnable_threads: 1
               uptime: 2 day 2 hour 4 min
         """
@@ -689,7 +689,7 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
                              '[1,2]*1000',
                              '-o', tmp_name)
             bench = pyperf.Benchmark.load(tmp_name)
-
+        
         self._check_track_memory_bench(bench, loops=5)
 
     def test_track_memory(self):

--- a/pyperf/tests/test_utils.py
+++ b/pyperf/tests/test_utils.py
@@ -146,9 +146,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(format_filesize(1),
                          '1 byte')
         self.assertEqual(format_filesize(10 * 1024),
-                         '10.0 kB')
+                         '10.0 kiB')
         self.assertEqual(format_filesize(12.4 * 1024 * 1024),
-                         '12.4 MB')
+                         '12.4 MiB')
 
     def test_get_python_names(self):
         self.assertEqual(utils.get_python_names('/usr/bin/python3.6',

--- a/pyperf/tests/test_utils.py
+++ b/pyperf/tests/test_utils.py
@@ -146,7 +146,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(format_filesize(1),
                          '1 byte')
         self.assertEqual(format_filesize(10 * 1024),
-                         '10.0 kiB')
+                         '10.0 KiB')
         self.assertEqual(format_filesize(12.4 * 1024 * 1024),
                          '12.4 MiB')
 


### PR DESCRIPTION
Previously, pyperf stated the memory usage as kB and MB, while strictly speaking, it was measured in KiB and MiB.
This commit makes it clear that the memory is measured using 2^10 and 2^20 bytes, not 10^3 and 10^6.

Closes #198 

Example output:
```raw
$ python3 -m pyperf timeit '[1,2]*1000' --track-memory
.....................
Mean +- std dev: 10.2 MiB +- 78.2 kiB
```