### PR TITLE
Fix Spelling Error

### DIFF
--- a/doc/system.rst
+++ b/doc/system.rst
@@ -23,7 +23,7 @@ be checked in benchmark metadata: it is enabled if the ``cpu_affinity``
 
 :func:`os.sched_setaffinity` is used to pin processes.
 
-Even if no CPU is isolated, CPU pining makes benchmarks more stable: use the
+Even if no CPU is isolated, CPU pinning makes benchmarks more stable: use the
 ``--affinity`` command line option.
 
 Check the CPU topology for HyperThreading and NUMA for best performances.


### PR DESCRIPTION
This pull request addresses several spelling issues in the benchmarking documentation, with a focus on correcting the term "***CPU pining***" to "***CPU pinning***"