### PR TITLE
Fix deprecated method in bench_time_func example

### DIFF
--- a/doc/examples/bench_time_func.py
+++ b/doc/examples/bench_time_func.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+import time
 import pyperf
 
 
 def bench_dict(loops, mydict):
     range_it = range(loops)
-    t0 = pyperf.perf_counter()
+    t0 = time.perf_counter()
 
     for _ in range_it:
         mydict['0']
@@ -18,7 +19,7 @@ def bench_dict(loops, mydict):
         mydict['800']
         mydict['900']
 
-    return pyperf.perf_counter() - t0
+    return time.perf_counter() - t0
 
 
 runner = pyperf.Runner()


### PR DESCRIPTION
Hi,
The example code in `bench_time_func.py` still uses `pyperf.perf_counter()`, which was deprecated in version 2.0.0. This pull request updates it to use `time.perf_counter()`, as recommended by the API documentation.