### PR TITLE
Implement --timeout when running benchmarks

### DIFF
--- a/doc/runner.rst
+++ b/doc/runner.rst
@@ -98,6 +98,7 @@ Option::
     --inherit-environ=VARS
     --copy-env
     --no-locale
+    --timeout TIMEOUT
     --track-memory
     --tracemalloc
 
@@ -140,6 +141,9 @@ Option::
   - ``LC_TELEPHONE``
   - ``LC_TIME``
 
+* ``--timeout``: set a timeout in seconds for an execution of the benchmark.
+  If the benchmark execution times out, pyperf exits with error code 124.
+  There is no time out by default.
 * ``--tracemalloc``: Use the ``tracemalloc`` module to track Python memory
   allocation and get the peak of memory usage in metadata
   (``tracemalloc_peak``). The module is only available on Python 3.4 and newer.

--- a/pyperf/_manager.py
+++ b/pyperf/_manager.py
@@ -7,6 +7,8 @@ from pyperf._formatter import format_number
 from pyperf._utils import MS_WINDOWS, create_environ, create_pipe, popen_killer
 
 
+EXIT_TIMEOUT = 60
+
 # Limit to 5 calibration processes
 # (10 if calibration is needed for loops and warmups)
 MAX_CALIBRATION = 5
@@ -107,7 +109,7 @@ class Manager:
             with popen_killer(proc):
                 try:
                     bench_json = rpipe.read_text()
-                    exitcode = proc.wait()
+                    exitcode = proc.wait(timeout=EXIT_TIMEOUT)
                 except TimeoutError as exc:
                     print(exc)
                     sys.exit(124)

--- a/pyperf/_manager.py
+++ b/pyperf/_manager.py
@@ -88,7 +88,7 @@ class Manager:
                              self.args.locale,
                              self.args.copy_env)
 
-        rpipe, wpipe = create_pipe(timeout=self.args.timeout)
+        rpipe, wpipe = create_pipe()
         with rpipe:
             with wpipe:
                 warg = wpipe.to_subprocess()
@@ -108,7 +108,7 @@ class Manager:
 
             with popen_killer(proc):
                 try:
-                    bench_json = rpipe.read_text()
+                    bench_json = rpipe.read_text(timeout=self.args.timeout)
                     exitcode = proc.wait(timeout=EXIT_TIMEOUT)
                 except TimeoutError as exc:
                     print(exc)

--- a/pyperf/_runner.py
+++ b/pyperf/_runner.py
@@ -183,6 +183,10 @@ class Runner:
                                  'value, used to calibrate the number of '
                                  'loops (default: %s)'
                             % format_timedelta(min_time))
+        parser.add_argument('--timeout',
+                            help='Specify a timeout in seconds for a single '
+                                 'benchmark execution (default: disabled)',
+                            type=strictly_positive)
         parser.add_argument('--worker', action='store_true',
                             help='Worker process, run the benchmark.')
         parser.add_argument('--worker-task', type=positive_or_nul, metavar='TASK_ID',

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -150,7 +150,7 @@ class TestRunner(unittest.TestCase):
                          tests.benchmark_as_json(result.bench))
 
     def test_pipe_with_timeout(self):
-        rpipe, wpipe = create_pipe(timeout=0.1)
+        rpipe, wpipe = create_pipe()
         with rpipe:
             with wpipe:
                 arg = wpipe.to_subprocess()
@@ -158,14 +158,23 @@ class TestRunner(unittest.TestCase):
                 # the Runner class
                 wpipe._fd = None
 
-                self.exec_runner('--pipe', str(arg), '--worker', '-l1', '-w1')
+                result = self.exec_runner('--pipe', str(arg),
+                                          '--worker', '-l1', '-w1')
 
             # Mock the select to make the read pipeline not ready
-            with mock.patch('pyperf._utils.select.select', return_value=(False, False, False)):
+            with mock.patch('pyperf._utils.select.select',
+                            return_value=(False, False, False)):
                 with self.assertRaises(TimeoutError) as cm:
-                    rpipe.read_text()
+                    rpipe.read_text(timeout=0.1)
                 self.assertEqual(str(cm.exception),
                          'Timed out after 0.1 seconds')
+
+            # Mock the select to make the read pipeline ready
+            with mock.patch('pyperf._utils.select.select',
+                            return_value=(True, False, False)):
+                bench_json = rpipe.read_text(timeout=0.1)
+                self.assertEqual(bench_json,
+                                tests.benchmark_as_json(result.bench))
 
     def test_json_exists(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -26,6 +26,9 @@ Result = collections.namedtuple('Result', 'runner bench stdout')
 
 
 class TestRunner(unittest.TestCase):
+
+    maxDiff = None
+
     def create_runner(self, args, **kwargs):
         # hack to be able to create multiple instances per process
         pyperf.Runner._created.clear()

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -174,7 +174,7 @@ class TestRunner(unittest.TestCase):
                             return_value=(True, False, False)):
                 bench_json = rpipe.read_text(timeout=0.1)
                 self.assertEqual(bench_json.rstrip(),
-                                tests.benchmark_as_json(result.bench).rstrip())
+                                 tests.benchmark_as_json(result.bench).rstrip())
 
     def test_json_exists(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -26,9 +26,6 @@ Result = collections.namedtuple('Result', 'runner bench stdout')
 
 
 class TestRunner(unittest.TestCase):
-
-    maxDiff = None
-
     def create_runner(self, args, **kwargs):
         # hack to be able to create multiple instances per process
         pyperf.Runner._created.clear()
@@ -176,8 +173,8 @@ class TestRunner(unittest.TestCase):
             with mock.patch('pyperf._utils.select.select',
                             return_value=(True, False, False)):
                 bench_json = rpipe.read_text(timeout=0.1)
-                self.assertEqual(bench_json,
-                                tests.benchmark_as_json(result.bench))
+                self.assertEqual(bench_json.rstrip(),
+                                tests.benchmark_as_json(result.bench).rstrip())
 
     def test_json_exists(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -149,6 +149,24 @@ class TestRunner(unittest.TestCase):
         self.assertEqual(bench_json,
                          tests.benchmark_as_json(result.bench))
 
+    def test_pipe_with_timeout(self):
+        rpipe, wpipe = create_pipe(timeout=1)
+        with rpipe:
+            with wpipe:
+                arg = wpipe.to_subprocess()
+                # Don't close the file descriptor, it is closed by
+                # the Runner class
+                wpipe._fd = None
+
+                self.exec_runner('--pipe', str(arg), '--worker', '-l1', '-w1')
+
+            # Mock the select to make the read pipeline not ready
+            with mock.patch('pyperf._utils.select.select', return_value=(False, False, False)):
+                with self.assertRaises(TimeoutError) as cm:
+                    rpipe.read_text()
+                self.assertEqual(str(cm.exception),
+                         'Timed out after 1 seconds')
+
     def test_json_exists(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:
 

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -150,7 +150,7 @@ class TestRunner(unittest.TestCase):
                          tests.benchmark_as_json(result.bench))
 
     def test_pipe_with_timeout(self):
-        rpipe, wpipe = create_pipe(timeout=1)
+        rpipe, wpipe = create_pipe(timeout=0.1)
         with rpipe:
             with wpipe:
                 arg = wpipe.to_subprocess()
@@ -165,7 +165,7 @@ class TestRunner(unittest.TestCase):
                 with self.assertRaises(TimeoutError) as cm:
                     rpipe.read_text()
                 self.assertEqual(str(cm.exception),
-                         'Timed out after 1 seconds')
+                         'Timed out after 0.1 seconds')
 
     def test_json_exists(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:


### PR DESCRIPTION
If the benchmark execution is exceeding the timeout execution, pyperf exits with an error 124. This error can be caught by pyperformance or other tool and report it back to the user.