### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   tox-jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Set up Python ${{ matrix.python }} using deadsnakes
-        uses: deadsnakes/action@v3.1.0
+        uses: deadsnakes/action@v3.2.0
         if: ${{ matrix.build == 'free-threading' }}
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,6 @@ jobs:
           - os: ubuntu-latest
             python: 'pypy3.9'
           - os: ubuntu-latest
-            python: 'pypy3.8'
-          - os: ubuntu-latest
-            python: '3.8'
-          - os: ubuntu-latest
             python: '3.9'
           - os: ubuntu-latest
             python: '3.10'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: pip

--- a/pyperf/tests/test_misc.py
+++ b/pyperf/tests/test_misc.py
@@ -67,11 +67,7 @@ class MiscTests(unittest.TestCase):
         self.assertRaises(ValueError, parse_run_list, '1,')
 
     def test_setup_version(self):
-        try:
-            from importlib.metadata import version
-        except ModuleNotFoundError:
-            # Workaround for Python 3.7
-            from importlib_metadata import version
+        from importlib.metadata import version
 
         self.assertEqual(pyperf.__version__, version("pyperf"))
 

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -97,10 +97,7 @@ class TestRunner(unittest.TestCase):
 
         try:
             s = pstats.Stats(name)
-            if sys.version_info < (3, 9):
-                assert len(s.stats)
-            else:
-                assert len(s.get_stats_profile().func_profiles)
+            assert len(s.get_stats_profile().func_profiles)
         finally:
             if os.path.isfile(name):
                 os.unlink(name)
@@ -123,10 +120,7 @@ class TestRunner(unittest.TestCase):
         try:
             import pstats
             s = pstats.Stats(name)
-            if sys.version_info < (3, 9):
-                assert len(s.stats)
-            else:
-                assert len(s.get_stats_profile().func_profiles)
+            assert len(s.get_stats_profile().func_profiles)
         finally:
             if os.path.isfile(name):
                 os.unlink(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = ["psutil>=5.9.0"]
 
 [project.optional-dependencies]
 dev = [
     'tox',
-    'importlib-metadata; python_version < "3.8"'
 ]
 
 [project.scripts]


### PR DESCRIPTION
Python 3.8 will be EOL in about a week, when 3.13 final is released.

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/
