### PR TITLE
Add warnings about too few or too many samples

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -345,6 +345,19 @@ Benchmark class
 
       Raise an exception if the benchmark has no values.
 
+   .. method:: required_nprocesses()
+
+      Determines the number of separate process runs that would be required
+      achieve stable results. Specifically, the target is to have 95% certainty
+      that there is a variance of less than 1%. If the result is greater than
+      the number of processes recorded in the input data, the value is
+      meaningless and only means "more samples are required".
+
+      The method used is described in this Wikipedia article about estimating
+      the sampling of a mean:
+
+      https://en.wikipedia.org/wiki/Sample_size_determination#Estimation_of_a_mean
+
    .. method:: update_metadata(metadata: dict)
 
       Update metadata of all runs of the benchmark.

--- a/pyperf/__main__.py
+++ b/pyperf/__main__.py
@@ -491,10 +491,13 @@ def display_benchmarks(args, show_metadata=False, hist=False, stats=False,
                 empty_line(output)
                 output.extend(lines)
 
+        contains_warning = False
         for line in output:
+            if line.startswith("WARNING:"):
+                contains_warning = True
             print(line)
 
-        if not output and only_checks:
+        if not contains_warning and only_checks:
             if len(data) == 1:
                 print("The benchmark seems to be stable")
             else:

--- a/pyperf/__main__.py
+++ b/pyperf/__main__.py
@@ -455,7 +455,8 @@ def display_benchmarks(args, show_metadata=False, hist=False, stats=False,
                                            dump=dump,
                                            checks=checks,
                                            result=result,
-                                           display_runs_args=display_runs_args)
+                                           display_runs_args=display_runs_args,
+                                           only_checks=only_checks)
 
             if bench_lines:
                 empty_line(lines)

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -424,6 +424,35 @@ class Benchmark:
             raise ValueError("MAD must be >= 0")
         return value
 
+    def required_nsamples(self):
+        """
+        Determines the number of samples that would be required to have 95%
+        certainty that the samples have a variance of less than 1%.
+
+        This is described in this Wikipedia article about estimating the sampling of
+        a mean:
+
+        https://en.wikipedia.org/wiki/Sample_size_determination#Estimation_of_a_mean
+        """
+        # Get the means of the values per run
+        values = []
+        for run in self._runs:
+            values.append(statistics.mean(run.values))
+
+        total = math.fsum(values)
+        mean = total / len(values)
+        stddev = statistics.stdev(values)
+        # Normalize the stddev so we can target "percentage changed" rather than
+        # absolute time
+        sigma = stddev / mean
+
+        # 95% certainty
+        Z = 1.96
+        # 1% variation
+        W = 0.01
+
+        return int(math.ceil((4 * Z ** 2 * sigma ** 2) / (W ** 2)))
+
     def percentile(self, p):
         if not (0 <= p <= 100):
             raise ValueError("p must be in the range [0; 100]")

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -463,7 +463,7 @@ class Benchmark:
         W = 0.01
 
         # (4Z²σ²)/(W²)
-        return int(math.ceil((4 * Z ** 2 * sigma ** 2) / (W ** 2)))
+        return math.ceil((4 * Z ** 2 * sigma ** 2) / (W ** 2))
 
     def percentile(self, p):
         if not (0 <= p <= 100):

--- a/pyperf/_bench.py
+++ b/pyperf/_bench.py
@@ -437,7 +437,11 @@ class Benchmark:
         # Get the means of the values per run
         values = []
         for run in self._runs:
-            values.append(statistics.mean(run.values))
+            if len(run.values):
+                values.append(statistics.mean(run.values))
+
+        if len(values) < 2:
+            return None
 
         total = math.fsum(values)
         mean = total / len(values)

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -425,7 +425,10 @@ def format_checks(bench, lines=None):
                  % (bench.format_value(stdev), percent, bench.format_value(mean)))
         else:
             # display a warning if the number of samples isn't enough to get a stable result
-            if required_nsamples > len(bench._runs):
+            if (
+                required_nsamples is not None and
+                required_nsamples > len(bench._runs)
+            ):
                 warn("Not enough samples to get a stable result (95% certainly of less than 1% variation)")
 
     # Minimum and maximum, detect obvious outliers
@@ -463,7 +466,10 @@ def format_checks(bench, lines=None):
         lines.append("Use pyperf stats, pyperf dump and pyperf hist to analyze results.")
         lines.append("Use --quiet option to hide these warnings.")
 
-    if required_nsamples < len(bench._runs) * 0.75:
+    if (
+        required_nsamples is not None and
+        required_nsamples < len(bench._runs) * 0.75
+    ):
         lines.append("Benchmark was run more times than necessary to get a stable result.")
         lines.append(
             "Consider passing processes=%d to the Runner constructor to save time." %

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -412,8 +412,7 @@ def format_checks(bench, lines=None, check_too_many_processes=False):
     mean = bench.mean()
     warnings = []
     warn = warnings.append
-
-    required_nprocesses = bench.required_nprocesses()
+    required_nprocesses = None
 
     # Display a warning if the standard deviation is greater than 10%
     # of the mean
@@ -425,6 +424,7 @@ def format_checks(bench, lines=None, check_too_many_processes=False):
                  % (bench.format_value(stdev), percent, bench.format_value(mean)))
         else:
             # display a warning if the number of samples isn't enough to get a stable result
+            required_nprocesses = bench.required_nprocesses()
             if (
                 required_nprocesses is not None and
                 required_nprocesses > len(bench._runs)
@@ -466,16 +466,18 @@ def format_checks(bench, lines=None, check_too_many_processes=False):
         lines.append("Use pyperf stats, pyperf dump and pyperf hist to analyze results.")
         lines.append("Use --quiet option to hide these warnings.")
 
-    if (
-        check_too_many_processes and
-        required_nprocesses is not None and
-        required_nprocesses < len(bench._runs) * 0.75
-    ):
-        lines.append("Benchmark was run more times than necessary to get a stable result.")
-        lines.append(
-            "Consider passing processes=%d to the Runner constructor to save time." %
-            required_nprocesses
-        )
+    if check_too_many_processes:
+        if required_nprocesses is None:
+            required_nprocesses = bench.required_nprocesses()
+        if (
+            required_nprocesses is not None and
+            required_nprocesses < len(bench._runs) * 0.75
+        ):
+            lines.append("Benchmark was run more times than necessary to get a stable result.")
+            lines.append(
+                "Consider passing processes=%d to the Runner constructor to save time." %
+                required_nprocesses
+            )
 
     # Warn if nohz_full+intel_pstate combo if found in cpu_config metadata
     for run in bench._runs:

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -400,7 +400,7 @@ def format_histogram(benchmarks, bins=20, extend=False, lines=None,
     return lines
 
 
-def format_checks(bench, lines=None):
+def format_checks(bench, lines=None, check_too_many_processes=False):
     if lines is None:
         lines = []
 
@@ -413,7 +413,7 @@ def format_checks(bench, lines=None):
     warnings = []
     warn = warnings.append
 
-    required_nsamples = bench.required_nsamples()
+    required_nprocesses = bench.required_nprocesses()
 
     # Display a warning if the standard deviation is greater than 10%
     # of the mean
@@ -426,8 +426,8 @@ def format_checks(bench, lines=None):
         else:
             # display a warning if the number of samples isn't enough to get a stable result
             if (
-                required_nsamples is not None and
-                required_nsamples > len(bench._runs)
+                required_nprocesses is not None and
+                required_nprocesses > len(bench._runs)
             ):
                 warn("Not enough samples to get a stable result (95% certainly of less than 1% variation)")
 
@@ -467,13 +467,14 @@ def format_checks(bench, lines=None):
         lines.append("Use --quiet option to hide these warnings.")
 
     if (
-        required_nsamples is not None and
-        required_nsamples < len(bench._runs) * 0.75
+        check_too_many_processes and
+        required_nprocesses is not None and
+        required_nprocesses < len(bench._runs) * 0.75
     ):
         lines.append("Benchmark was run more times than necessary to get a stable result.")
         lines.append(
             "Consider passing processes=%d to the Runner constructor to save time." %
-            required_nsamples
+            required_nprocesses
         )
 
     # Warn if nohz_full+intel_pstate combo if found in cpu_config metadata
@@ -568,7 +569,7 @@ def format_result(bench):
 
 def format_benchmark(bench, checks=True, metadata=False,
                      dump=False, stats=False, hist=False, show_name=False,
-                     result=True, display_runs_args=None):
+                     result=True, display_runs_args=None, only_checks=False):
     lines = []
 
     if metadata:
@@ -587,7 +588,7 @@ def format_benchmark(bench, checks=True, metadata=False,
         format_stats(bench, lines=lines)
 
     if checks:
-        format_checks(bench, lines=lines)
+        format_checks(bench, lines=lines, check_too_many_processes=only_checks)
 
     if result:
         empty_line(lines)

--- a/pyperf/_cli.py
+++ b/pyperf/_cli.py
@@ -413,7 +413,7 @@ def format_checks(bench, lines=None):
     warnings = []
     warn = warnings.append
 
-    required_nsamples = bench.required_samples()
+    required_nsamples = bench.required_nsamples()
 
     # Display a warning if the standard deviation is greater than 10%
     # of the mean

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -478,16 +478,11 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
             22.8 ms:  3 ##############
             22.9 ms:  4 ###################
             22.9 ms:  4 ###################
-            Benchmark was run more times than necessary to get a stable result.
-            Consider passing processes=7 to the Runner constructor to save time.
         """)
         self.check_command(expected, 'hist', TELCO, env=env)
 
     def test_show(self):
         expected = ("""
-            Benchmark was run more times than necessary to get a stable result.
-            Consider passing processes=7 to the Runner constructor to save time.
-
             Mean +- std dev: 22.5 ms +- 0.2 ms
         """)
         self.check_command(expected, 'show', TELCO)
@@ -523,8 +518,6 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
             100th percentile: 22.9 ms (+2% of the mean) -- maximum
 
             Number of outlier (out of 22.0 ms..23.0 ms): 0
-            Benchmark was run more times than necessary to get a stable result.
-            Consider passing processes=7 to the Runner constructor to save time.
         """)
         self.check_command(expected, 'stats', TELCO)
 
@@ -635,6 +628,14 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
 
     def test_check_stable(self):
         stdout = self.run_command('check', TELCO)
+        self.assertTrue(
+            textwrap.dedent(
+                """
+                Benchmark was run more times than necessary to get a stable result.
+                Consider passing processes=7 to the Runner constructor to save time.
+                """
+            ).strip() in stdout.rstrip()
+        )
         self.assertTrue(
             'The benchmark seems to be stable' in
             stdout.rstrip()

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -478,11 +478,16 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
             22.8 ms:  3 ##############
             22.9 ms:  4 ###################
             22.9 ms:  4 ###################
+            Benchmark was run more times than necessary to get a stable result.
+            Consider passing processes=7 to the Runner constructor to save time.
         """)
         self.check_command(expected, 'hist', TELCO, env=env)
 
     def test_show(self):
         expected = ("""
+            Benchmark was run more times than necessary to get a stable result.
+            Consider passing processes=7 to the Runner constructor to save time.
+
             Mean +- std dev: 22.5 ms +- 0.2 ms
         """)
         self.check_command(expected, 'show', TELCO)
@@ -518,6 +523,8 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
             100th percentile: 22.9 ms (+2% of the mean) -- maximum
 
             Number of outlier (out of 22.0 ms..23.0 ms): 0
+            Benchmark was run more times than necessary to get a stable result.
+            Consider passing processes=7 to the Runner constructor to save time.
         """)
         self.check_command(expected, 'stats', TELCO)
 
@@ -628,8 +635,10 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
 
     def test_check_stable(self):
         stdout = self.run_command('check', TELCO)
-        self.assertEqual(stdout.rstrip(),
-                         'The benchmark seems to be stable')
+        self.assertTrue(
+            'The benchmark seems to be stable' in
+            stdout.rstrip()
+        )
 
     def test_command(self):
         command = [sys.executable, '-c', 'pass']
@@ -689,7 +698,7 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
                              '[1,2]*1000',
                              '-o', tmp_name)
             bench = pyperf.Benchmark.load(tmp_name)
-        
+
         self._check_track_memory_bench(bench, loops=5)
 
     def test_track_memory(self):

--- a/pyperf/tests/test_perf_cli.py
+++ b/pyperf/tests/test_perf_cli.py
@@ -628,16 +628,16 @@ class TestPerfCLI(BaseTestCase, unittest.TestCase):
 
     def test_check_stable(self):
         stdout = self.run_command('check', TELCO)
-        self.assertTrue(
+        self.assertIn(
             textwrap.dedent(
                 """
                 Benchmark was run more times than necessary to get a stable result.
                 Consider passing processes=7 to the Runner constructor to save time.
                 """
-            ).strip() in stdout.rstrip()
+            ).strip(), stdout.rstrip()
         )
-        self.assertTrue(
-            'The benchmark seems to be stable' in
+        self.assertIn(
+            'The benchmark seems to be stable',
             stdout.rstrip()
         )
 


### PR DESCRIPTION
Related to https://github.com/python/pyperformance/issues/372.  Once this is merged, we can reduce the number of iterations in pyperformance.