### PR TITLE
.github: Add ARM64 CI for pyperf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     name: ${{ matrix.os }} - ${{ matrix.python }} ${{ matrix.build }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
         python: ['3.12']
         build: ['']
         include:


### PR DESCRIPTION
See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/