### PR TITLE
Recognise CPython as a JIT implementation

### DIFF
--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -184,7 +184,8 @@ def python_has_jit():
     elif implementation_name in ['graalpython', 'graalpy']:
         return True
     elif implementation_name == 'cpython':
-        if (jit_module := getattr(sys, '_jit')) is not None:
+        jit_module = getattr(sys, '_jit', None)
+        if jit_module is not None:
             return jit_module.is_enabled()
         return False
     elif hasattr(sys, "pyston_version_info") or "pyston_lite" in sys.modules:


### PR DESCRIPTION
Since CPython 3.13, there has been an experimental JIT. In 3.15, the JIT now has a slight bit of warmup. While the warmup is actually a lot lower than PyPy/GraalPy, it's still there. So we should detect the CPython JIT and account for that.