### PR TITLE
gh-239: Add `metadata["phase"]`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -512,6 +512,7 @@ HookBase class
       Called when the hook is completed for a process.
 
       May add any information collected to the passed-in ``metadata`` dictionary.
+      The ``phase`` metadata identifies the run phase and sample type.
 
 
 Runner class
@@ -780,6 +781,9 @@ Other:
 
 * ``perf_version``: Version of the ``pyperf`` module
 * ``unit``: Unit of values: ``byte``, ``integer`` or ``second``
+* ``phase`` (tuple or list of two non-empty strings): run phase and sample
+  type, set to one of ``("calibration", "loops")``, ``("calibration",
+  "warmup")``, ``("measurement", "warmup")`` or ``("measurement", "value")``.
 * ``calibrate_loops`` (``int >= 1``): number of loops computed in a loops
   calibration run
 * ``recalibrate_loops`` (``int >= 1``): number of loops computed in a loops

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+* Feature: pyperf now stores ``phase`` run metadata in JSON files to identify
+  calibration and measurement samples. Hooks can also inspect this metadata in
+  :meth:`HookBase.teardown` to distinguish calibration loops, calibration
+  warmups, measurement warmups, and measurement values.
+  Patch by Maurycy Pawłowski-Wieroński.
+
 Version 2.10.0 (2026-02-07)
 ---------------------------
 

--- a/pyperf/_metadata.py
+++ b/pyperf/_metadata.py
@@ -48,6 +48,12 @@ def is_tags(value):
     return all(isinstance(x, str) and x not in ('all', '') for x in value)
 
 
+def is_phase(value):
+    if not isinstance(value, (tuple, list)):
+        return False
+    return len(value) == 2 and all(isinstance(x, str) and x for x in value)
+
+
 def parse_load_avg(value):
     if isinstance(value, NUMBER_TYPES):
         return value
@@ -69,6 +75,7 @@ LOOPS = _MetadataInfo(format_number, (int,), is_strictly_positive, 'integer')
 WARMUPS = _MetadataInfo(format_number, (int,), is_positive, 'integer')
 SECONDS = _MetadataInfo(format_seconds, NUMBER_TYPES, is_positive, 'second')
 TAGS = _MetadataInfo(format_generic, (list,), is_tags, 'tag')
+PHASE = _MetadataInfo(format_generic, (tuple, list), is_phase, None)
 
 # Registry of metadata keys
 METADATA = {
@@ -92,6 +99,7 @@ METADATA = {
     'calibrate_warmups': WARMUPS,
     'recalibrate_warmups': WARMUPS,
     'tags': TAGS,
+    'phase': PHASE,
 }
 
 DEFAULT_METADATA_INFO = _MetadataInfo(format_generic, METADATA_VALUE_TYPES, None, None)

--- a/pyperf/_worker.py
+++ b/pyperf/_worker.py
@@ -114,6 +114,15 @@ class WorkerTask:
 
             index += 1
 
+        if calibrate_loops:
+            self.metadata["phase"] = ("calibration", "loops")
+        elif is_warmup and (args.calibrate_warmups or args.recalibrate_warmups):
+            self.metadata["phase"] = ("calibration", "warmup")
+        elif is_warmup:
+            self.metadata["phase"] = ("measurement", "warmup")
+        else:
+            self.metadata["phase"] = ("measurement", "value")
+
         for hook in hook_managers.values():
             hook.teardown(self.metadata)
 

--- a/pyperf/tests/test_bench.py
+++ b/pyperf/tests/test_bench.py
@@ -1,6 +1,7 @@
 import datetime
 import errno
 import gzip
+import json
 import unittest
 
 import pyperf
@@ -216,6 +217,40 @@ class BenchmarkTests(unittest.TestCase):
             bench2 = pyperf.Benchmark.load(tmp_name)
 
         self.check_benchmarks_equal(bench, bench2)
+
+    def test_dump_phase_metadata(self):
+        runs = [
+            pyperf.Run(
+                (),
+                warmups=[(1, 2.92e-7), (64, 2.65e-9)],
+                metadata={'name': 'bench',
+                          'loops': 64,
+                          'calibrate_loops': 64,
+                          'phase': ('calibration', 'loops')},
+                collect_metadata=False),
+            pyperf.Run(
+                [2.5949900301497353e-9, 2.633662268304582e-9],
+                warmups=[(64, 2.6324198845045776e-9)],
+                metadata={'name': 'bench',
+                          'loops': 64,
+                          'phase': ('measurement', 'value')},
+                collect_metadata=False),
+        ]
+        bench = pyperf.Benchmark(runs)
+
+        bench_json = tests.benchmark_as_json(bench)
+        data = json.loads(bench_json)
+        json_runs = data['benchmarks'][0]['runs']
+        self.assertEqual(json_runs[0]['metadata']['phase'],
+                         ['calibration', 'loops'])
+        self.assertEqual(json_runs[1]['metadata']['phase'],
+                         ['measurement', 'value'])
+
+        bench2 = pyperf.Benchmark.loads(bench_json)
+        phases = [run.get_metadata()['phase'] for run in bench2.get_runs()]
+        self.assertEqual(phases,
+                         [['calibration', 'loops'],
+                          ['measurement', 'value']])
 
     def test_dump_replace(self):
         bench = self.create_dummy_benchmark()

--- a/pyperf/tests/test_bench.py
+++ b/pyperf/tests/test_bench.py
@@ -69,6 +69,25 @@ class RunTests(unittest.TestCase):
                          collect_metadata=False)
         self.assertEqual(run.get_metadata()['load_avg_1min'], 0.0)
 
+    def test_phase_metadata(self):
+        for value in (('measurement', 'value'), ['calibration', 'loops']):
+            with self.subTest(value=value):
+                run = pyperf.Run([1.0], metadata={'phase': value},
+                                 collect_metadata=False)
+                self.assertEqual(run.get_metadata()['phase'], value)
+
+        invalid_values = (
+            'measurement:value',
+            ('measurement',),
+            ('measurement', ''),
+            ('measurement', 1),
+        )
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    pyperf.Run([1.0], metadata={'phase': value},
+                               collect_metadata=False)
+
     def test_name(self):
         # name must be non-empty
         with self.assertRaises(ValueError):

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -80,8 +80,6 @@ class TestRunner(unittest.TestCase):
         result = self.exec_runner('--worker', '-l1', '-w1')
         self.assertRegex(result.stdout,
                          r'^bench: Mean \+- std dev: 1\.00 sec \+- 0\.00 sec\n$')
-        self.assertEqual(result.bench.get_metadata()['phase'],
-                         ('measurement', 'value'))
 
     def test_debug_single_value(self):
         result = self.exec_runner('--debug-single-value', '--worker')
@@ -288,8 +286,6 @@ class TestRunner(unittest.TestCase):
         run = runs[0]
 
         self.assertEqual(run.warmups, warmups)
-        self.assertEqual(run.get_metadata()['phase'],
-                         ('calibration', 'loops'))
 
     def test_calibrate_loops(self):
         args = ['--worker', '-w0', '-n2', '--min-time=1.0',
@@ -522,6 +518,43 @@ class TestRunner(unittest.TestCase):
                          ' '.join(map(shell_quote, args)))
         self.assertEqual(bench.get_metadata()["hooks"],
                          "_test_hook")
+
+    def test_hook_teardown_phase_metadata(self):
+        def time_func(loops):
+            return 1.0
+
+        def hook_phases(args):
+            phases = []
+
+            class PhaseHook(HookBase):
+                name = "phase_hook"
+
+                @staticmethod
+                def load():
+                    return PhaseHook
+
+                def teardown(self, metadata):
+                    phases.append(metadata["phase"])
+
+            args = args + ["--hook", PhaseHook.name]
+            runner = self.create_runner(args, hooks=[PhaseHook])
+            with tests.capture_stdout():
+                runner.bench_time_func('bench', time_func)
+            return phases
+
+        self.assertEqual(
+            hook_phases('-l1 -w1 -n1 --worker'.split()),
+            [('measurement', 'warmup'), ('measurement', 'value')])
+        self.assertEqual(
+            hook_phases('--calibrate-loops -w0 -n1 --min-time=1.0 '
+                        '--worker'.split()),
+            [('calibration', 'loops')])
+
+        with mock.patch('pyperf._worker.WorkerTask.test_calibrate_warmups',
+                        return_value=True):
+            self.assertEqual(
+                hook_phases('--calibrate-warmups -l1 -n1 --worker'.split()),
+                [('calibration', 'warmup')])
 
     def test_custom_hook(self):
         class State:

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -80,6 +80,8 @@ class TestRunner(unittest.TestCase):
         result = self.exec_runner('--worker', '-l1', '-w1')
         self.assertRegex(result.stdout,
                          r'^bench: Mean \+- std dev: 1\.00 sec \+- 0\.00 sec\n$')
+        self.assertEqual(result.bench.get_metadata()['phase'],
+                         ('measurement', 'value'))
 
     def test_debug_single_value(self):
         result = self.exec_runner('--debug-single-value', '--worker')
@@ -286,6 +288,8 @@ class TestRunner(unittest.TestCase):
         run = runs[0]
 
         self.assertEqual(run.warmups, warmups)
+        self.assertEqual(run.get_metadata()['phase'],
+                         ('calibration', 'loops'))
 
     def test_calibrate_loops(self):
         args = ['--worker', '-w0', '-n2', '--min-time=1.0',

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -542,19 +542,24 @@ class TestRunner(unittest.TestCase):
                 runner.bench_time_func('bench', time_func)
             return phases
 
-        self.assertEqual(
-            hook_phases('-l1 -w1 -n1 --worker'.split()),
-            [('measurement', 'warmup'), ('measurement', 'value')])
-        self.assertEqual(
-            hook_phases('--calibrate-loops -w0 -n1 --min-time=1.0 '
-                        '--worker'.split()),
-            [('calibration', 'loops')])
+        cases = (
+            ('measurement',
+             '-l1 -w1 -n1 --worker',
+             [('measurement', 'warmup'), ('measurement', 'value')]),
+            ('calibrate loops',
+             '--calibrate-loops -w0 -n1 --min-time=1.0 --worker',
+             [('calibration', 'loops')]),
+        )
+        for name, args, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(hook_phases(args.split()), expected)
 
-        with mock.patch('pyperf._worker.WorkerTask.test_calibrate_warmups',
-                        return_value=True):
-            self.assertEqual(
-                hook_phases('--calibrate-warmups -l1 -n1 --worker'.split()),
-                [('calibration', 'warmup')])
+        with self.subTest(name='calibrate warmups'):
+            with mock.patch('pyperf._worker.WorkerTask.test_calibrate_warmups',
+                            return_value=True):
+                self.assertEqual(
+                    hook_phases('--calibrate-warmups -l1 -n1 --worker'.split()),
+                    [('calibration', 'warmup')])
 
     def test_custom_hook(self):
         class State:


### PR DESCRIPTION
Hooks today receive `metadata` but cannot tell which `_compute_values` just ran. The PR adds `phase` to the `metadata`.

| phase | when |
|---|---|
| `("calibration", "warmup")` | `calibrate_warmups()`, including `--recalibrate-warmups` |
| `("calibration", "loops")` | `calibrate_loops()`, including `--recalibrate-loops` |
| `("measurement", "warmup")` | `compute_warmups_values()` warmup samples (skipped when `--warmups 0`) |
| `("measurement", "value")` | `compute_warmups_values()` value samples |

Recalibration is implicit and hooks can use `metadata["recalibrate_warmups"]` or `metadata["recalibrate_loops"]`.

`phase` is a tuple, but after a JSON round-trip it is a list

As a bonus, `benchmarks.runs.metadata[]` is now explicit: 

```json
{
  "benchmarks": [
    {
      "runs": [
        {
          "metadata": {
            "calibrate_loops": 67108864,
            "date": "2026-05-27 23:54:30.678184",
            "duration": 0.7158581660478376,
            "mem_max_rss": 27230208,
            "phase": [
              "calibration",
              "loops"
            ],
            "uptime": 634803.6837940216
          },
          "warmups": [[1, 2.92e-07], "... (elided)", [67108864, 2.65e-09]]
        },
        {
          "metadata": {
            "date": "2026-05-27 23:54:31.261364",
            "duration": 0.536709374981001,
            "mem_max_rss": 27426816,
            "phase": [
              "measurement",
              "value"
            ],
            "uptime": 634804.2667930126
          },
          "values": [
            2.5949900301497353E-9,
            2.633662268304582E-9
          ],
          "warmups": [
            [
              67108864,
              2.6324198845045776E-9
            ]
          ]
        }
      ]
    }
  ],
  "metadata": {
    "boot_time": "2026-05-20 15:34:27",
    "...": "(removed for brevity)"
  },
  "version": "1.0"
}
```

Feature requested by [gc-monitor](https://github.com/sergey-miryanov/gc-monitor) in #239.

Please see https://github.com/psf/pyperf/issues/239#issuecomment-4553786308 for a possible future direction in the hook API.

cr @sergey-miryanov @vstinner
resolve #239