### PR TITLE
Restore JIT warmup calibration default

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -517,7 +517,7 @@ HookBase class
 Runner class
 ------------
 
-.. class:: Runner(values=3, warmups=1, processes=20, loops=0, min_time=0.1, metadata=None, show_name=True, program_args=None, add_cmdline_args=None, hooks=None)
+.. class:: Runner(values=3, warmups=None, processes=20, loops=0, min_time=0.1, metadata=None, show_name=True, program_args=None, add_cmdline_args=None, hooks=None)
 
    Tool to run a benchmark in text mode.
 

--- a/doc/runner.rst
+++ b/doc/runner.rst
@@ -22,7 +22,7 @@ Default without JIT (ex: CPython): 20 processes, 3 values per process (total: 60
 values), and 1 warmup.
 
 Default with a JIT (ex: PyPy): 6 processes, 10 values per process (total: 60
-values), and 10 warmups.
+values), and automatic warmup calibration.
 
 * ``--rigorous``: Spend longer running tests to get more accurate results.
   Multiply the number of ``PROCESSES`` by 2. Default: 40 processes and 3
@@ -35,7 +35,7 @@ values), and 10 warmups.
 * ``VALUES``: number of values per process
   (default: ``3``, or ``10`` with a JIT)
 * ``WARMUPS``: the number of ignored values used to warmup to benchmark
-  (default: ``1``, or ``10`` with a JIT)
+  (default: ``1``, or automatically calibrated with a JIT)
 * ``LOOPS``: number of loops per value. ``x^y`` syntax is accepted, example:
   ``--loops=2^8`` uses ``256`` iterations. By default, the timer is calibrated
   to get raw values taking at least ``MIN_TIME`` seconds.

--- a/pyperf/_runner.py
+++ b/pyperf/_runner.py
@@ -77,7 +77,7 @@ class Runner:
                  loops=0, min_time=0.1, metadata=None,
                  show_name=True,
                  program_args=None, add_cmdline_args=None,
-                 _argparser=None, warmups=1, hooks=None):
+                 _argparser=None, warmups=None, hooks=None):
 
         # Watchdog: ensure that only once instance of Runner (or a Runner
         # subclass) is created per process to prevent bad surprises

--- a/pyperf/tests/test_runner.py
+++ b/pyperf/tests/test_runner.py
@@ -85,6 +85,21 @@ class TestRunner(unittest.TestCase):
         result = self.exec_runner('--debug-single-value', '--worker')
         self.assertEqual(result.bench.get_nvalue(), 1)
 
+    def test_default_warmups_without_jit(self):
+        with mock.patch('pyperf.python_has_jit', return_value=False):
+            runner = self.create_runner([])
+        self.assertEqual(runner.args.warmups, 1)
+
+    def test_default_warmups_with_jit(self):
+        with mock.patch('pyperf.python_has_jit', return_value=True):
+            runner = self.create_runner([])
+        self.assertIsNone(runner.args.warmups)
+
+    def test_runner_warmups_argument(self):
+        with mock.patch('pyperf.python_has_jit', return_value=True):
+            runner = self.create_runner([], warmups=5)
+        self.assertEqual(runner.args.warmups, 5)
+
     def test_profile_time_func(self):
         with tempfile.NamedTemporaryFile('wb+') as tmp:
             name = tmp.name


### PR DESCRIPTION
pyperf has the capability to do automatic warmup calibration for the interpreters that have a JIT. However, the CLI would set the default value of the `--warmup` option to 1, making it impossible to to use the warmup calibration from the CLI because you can't pass None to an int option.

The `warmup` argument used to have default `None`, but it was removed in #155 and then reintroduced again in #194 with default `1`. This PR restores it back to `None`. This shouldn't change anything for CPython, since the `None` gets converted to `1`  for interpreters without a JIT.